### PR TITLE
Removing printing, tests should be silent

### DIFF
--- a/beast2/src/test/java/phylonco/beast/evolution/errormodel/GT16ErrorModelTest.java
+++ b/beast2/src/test/java/phylonco/beast/evolution/errormodel/GT16ErrorModelTest.java
@@ -118,14 +118,11 @@ public class GT16ErrorModelTest {
         errorModel.initAndValidate();
 
         for (int trueState = 0; trueState < datatype.getStateCount(); trueState++) {
-            String line = "";
             for (int observedState = 0; observedState < datatype.getStateCount(); observedState++) {
                 double calcProb = errorModel.getProbability(observedState, trueState);
                 double expectedProb = expectedMatrix[trueState][observedState];
                 assertEquals(expectedProb, calcProb, DELTA);
-                line += expectedProb + " ";
             }
-            System.out.println(line);
         }
     }
 

--- a/beast2/src/test/java/phylonco/beast/evolution/likelihood/TreeLikelihoodWithErrorFastTest.java
+++ b/beast2/src/test/java/phylonco/beast/evolution/likelihood/TreeLikelihoodWithErrorFastTest.java
@@ -93,10 +93,6 @@ public class TreeLikelihoodWithErrorFastTest {
         double logP = likelihood.calculateLogP();
         double expectedLogP = -2.3063595712034233;
         assertEquals(expectedLogP, logP, DELTA);
-
-        System.out.println("seq A: " + data.getSequenceAsString("a"));
-        System.out.println("seq B: " + data.getSequenceAsString("b"));
-        System.out.println("likelihood: " + logP);
     }
 
     private double calculateLikelihoodBinary(String seq, String alpha, String beta) {

--- a/beast2/src/test/java/phylonco/beast/evolution/likelihood/TreeLikelihoodWithErrorSlowTest.java
+++ b/beast2/src/test/java/phylonco/beast/evolution/likelihood/TreeLikelihoodWithErrorSlowTest.java
@@ -93,10 +93,6 @@ public class TreeLikelihoodWithErrorSlowTest {
         double logP = likelihood.calculateLogP();
         double expectedLogP = -2.3063595712034233;
         assertEquals(expectedLogP, logP, DELTA);
-
-        System.out.println("seq A: " + data.getSequenceAsString("a"));
-        System.out.println("seq B: " + data.getSequenceAsString("b"));
-        System.out.println("likelihood: " + logP);
     }
 
     private double calculateLikelihoodBinary(String seq, String alpha, String beta) {


### PR DESCRIPTION
Removed some extra printing from unit tests.

Tests should be silent if passing. If not passing, they should raise an error, which will be reported by a framework.

There is still quite a lot of printing, but I couldn't find the source. I suspect it is something in the BEAST2 and not in the package.