### PR TITLE
fix: set operator weight to 1.0 in DiscreteGaussianErrorModelToBEAST to allow sigma sampling

### DIFF
--- a/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/DiscreteGaussianErrorModelToBEAST.java
+++ b/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/DiscreteGaussianErrorModelToBEAST.java
@@ -122,10 +122,10 @@ public class DiscreteGaussianErrorModelToBEAST
     private void modifyScaleFactor (RealParameter parameter, BEASTContext context) {
         BactrianRandomWalkOperator operator = new BactrianRandomWalkOperator();
         operator.setInputValue("parameter", parameter);
-        operator.setInputValue("weight", context.getOperatorWeight(parameter.getDimension() - 1));
+        operator.setInputValue("weight", 1.0);
         operator.setInputValue("scaleFactor",0.3);
         operator.initAndValidate();
-        operator.setID(parameter.getID() + ".deltaExchange");
+        operator.setID(parameter.getID() + ".BactrianRandomWalk");
         // add operator
         context.addExtraOperator(operator);
         // skip default operator schedule


### PR DESCRIPTION
## Changes
- Modified `modifyScaleFactor()` in `DiscreteGaussianErrorModelToBEAST.java`
- Added `BactrianRandomWalkOperator` with correct weight (1.0) for sigma

@kche309 Hi Kylie, Please check when you free, thanks!