### PR TITLE
Port integrated read-count genotype model (PR #128) to beast3

### DIFF
--- a/phylonco-beast/src/main/java/module-info.java
+++ b/phylonco-beast/src/main/java/module-info.java
@@ -33,6 +33,8 @@ module phylonco.beast {
             phylonco.beast.evolution.likelihood.TreeLikelihoodWithError,
             phylonco.beast.evolution.likelihood.TreeLikelihoodWithErrorFast,
             phylonco.beast.evolution.likelihood.TreeLikelihoodWithErrorSlow,
+            phylonco.beast.evolution.likelihood.ReadCountTreeLikelihood,
+            phylonco.beast.evolution.likelihood.SampledGenotypeLogger,
             phylonco.beast.evolution.substitutionmodel.BinarySubstitutionModel,
             phylonco.beast.evolution.substitutionmodel.GT16,
             phylonco.beast.evolution.substitutionmodel.GT10,

--- a/phylonco-beast/src/main/java/phylonco/beast/evolution/likelihood/ReadCountTreeLikelihood.java
+++ b/phylonco-beast/src/main/java/phylonco/beast/evolution/likelihood/ReadCountTreeLikelihood.java
@@ -1,0 +1,248 @@
+package phylonco.beast.evolution.likelihood;
+
+import beast.base.core.Description;
+import beast.base.core.Input;
+import beast.base.evolution.alignment.Alignment;
+import beast.base.evolution.alignment.Sequence;
+import beast.base.evolution.datatype.DataType;
+import beast.base.evolution.likelihood.BeerLikelihoodCore;
+import beast.base.evolution.sitemodel.SiteModelInterface;
+import beast.base.evolution.substitutionmodel.SubstitutionModel;
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beast.base.inference.StateNode;
+import mutablealignment.MutableAlignment;
+import phylonco.beast.evolution.datatype.NucleotideDiploid10;
+import phylonco.beast.evolution.datatype.NucleotideDiploid16;
+import phylonco.beast.evolution.datatype.ReadCount;
+import phylonco.beast.evolution.readcountmodel.LikelihoodReadCountModel;
+
+import java.util.List;
+
+/**
+ * Tree likelihood that integrates the latent single-cell genotype alignment OUT of the
+ * posterior analytically, instead of sampling it as a {@code MutableAlignment} StateNode.
+ *
+ * <p>Each tip's Felsenstein partial-likelihood vector is set to
+ * {@code P(read counts at cell t, site j | genotype g)} for every genotype {@code g}, taken
+ * from {@link LikelihoodReadCountModel#logLiklihoodRC}. Standard pruning over the GT16/GT10
+ * substitution model then marginalises the genotypes. This collapses the former two-factor
+ * posterior (MATreeLikelihood over sampled genotypes + LikelihoodReadCountModel) into a single
+ * factor and removes the genotype StateNode and all its Gibbs operators.</p>
+ *
+ * <p>The read-count likelihoods are tiny, so each tip's partial vector is rescaled per-site by
+ * its maximum before upload (max-normalisation); the summed log of those per-(tip,site) maxima
+ * is held in {@link #globalLogOffset} and added back to {@code logP}.</p>
+ *
+ * <p>There is no genotype alignment in the model — the only data is the {@code ReadCount}. The
+ * {@code data} Alignment that the parent {@link TreeLikelihoodWithErrorFast} needs for taxa / site
+ * count / pattern indexing is built internally as an identity-pattern scaffold from the read counts
+ * (taxa, site count) and the genotype datatype implied by the GT10/GT16 substitution model; its
+ * genotype values are ignored. The read-count model referenced via {@link #readCountModelInput}
+ * must NOT also be added to the posterior CompoundDistribution (it would be double-counted); it
+ * stays in the model graph as this likelihood's input, so BEAST still drives its store/restore.</p>
+ */
+@Description("Tree likelihood that integrates single-cell genotypes out via read-count tip partials")
+public class ReadCountTreeLikelihood extends TreeLikelihoodWithErrorFast {
+
+    final public Input<LikelihoodReadCountModel> readCountModelInput = new Input<>(
+            "readCountModel",
+            "read-count model supplying per-genotype likelihoods P(reads | genotype) for the tip partials",
+            Input.Validate.REQUIRED);
+
+    private LikelihoodReadCountModel readCountModel;
+
+    public ReadCountTreeLikelihood() {
+        // no genotype alignment in the integrated model; the scaffold is built from the read counts
+        dataInput.setRule(Input.Validate.OPTIONAL);
+    }
+
+    // alignment-taxon-index -> ReadCount-row-index
+    private int[] alignToRC;
+
+    // the 7 read-count parameters; a change in any forces a tip-partial rebuild.
+    // Typed as StateNode because the beast3 spec params are a mix of RealScalarParam and
+    // RealVectorParam (both extend StateNode, which carries somethingIsDirty()).
+    private StateNode[] rcParams;
+
+    // summed log of the per-(tip,site) max-normalisation factors; added back to logP
+    private double globalLogOffset = 0.0;
+    private double storedGlobalLogOffset = 0.0;
+
+    @Override
+    public void initAndValidate() {
+        readCountModel = readCountModelInput.get();
+
+        // genotype datatype implied by the GT10/GT16 substitution model (10 or 16 states)
+        SubstitutionModel substModel =
+                ((SiteModelInterface.Base) siteModelInput.get()).getSubstitutionModel();
+        int stateCount = substModel.getStateCount();
+        if (stateCount != 10 && stateCount != 16) {
+            throw new IllegalArgumentException(
+                    "ReadCountTreeLikelihood expects a 10- or 16-state genotype substitution model "
+                    + "(GT10 / GT16), got " + stateCount);
+        }
+        DataType genotypeDataType = stateCount == 16 ? new NucleotideDiploid16() : new NucleotideDiploid10();
+
+        // tell the read-count helper the genotype datatype (it has no genotype alignment) and refresh
+        // its cached Gamma tables before the first getLeafPartials traversal super.initAndValidate triggers
+        readCountModel.setDataType(genotypeDataType);
+        readCountModel.initialize();
+        alignToRC = readCountModel.getAlignToRCIndex();
+        rcParams = new StateNode[]{
+                readCountModel.epsilonInput.get(),
+                readCountModel.deltaInput.get(),
+                readCountModel.tInput.get(),
+                readCountModel.vInput.get(),
+                readCountModel.sInput.get(),
+                readCountModel.w1Input.get(),
+                readCountModel.w2Input.get(),
+        };
+
+        // build the identity-pattern scaffold the parent TreeLikelihood needs, from the read counts
+        // (there is no genotype alignment in the model). Kept internal — not an XML input.
+        if (dataInput.get() == null) {
+            dataInput.setValue(buildScaffold(genotypeDataType), this);
+        }
+
+        // super.initAndValidate() builds the initial tip partials via setPartials -> getLeafPartials,
+        // accumulating globalLogOffset from 0.
+        globalLogOffset = 0.0;
+        super.initAndValidate();
+
+        Alignment data = dataInput.get();
+        if (data.getPatternCount() != data.getSiteCount()) {
+            throw new IllegalArgumentException(
+                    "ReadCountTreeLikelihood requires an identity-pattern scaffold (patternCount == "
+                    + "siteCount); pattern compression would break the per-site read-count mapping.");
+        }
+        if (m_siteModel.getProportionInvariant() != 0.0) {
+            throw new IllegalArgumentException(
+                    "ReadCountTreeLikelihood does not support proportionInvariant > 0 "
+                    + "(it would add an unscaled term to constant-pattern root slots). Set it to 0.");
+        }
+    }
+
+    /**
+     * Drops the internally-built scaffold from the {@code data} input so a generator does not
+     * serialise it into the XML (the integrated model has no genotype alignment — the only data is
+     * the read counts). BEAST rebuilds the scaffold from the read counts in {@link #initAndValidate}
+     * when it parses and initialises the run.
+     */
+    public void dropScaffoldInput() {
+        dataInput.setValue(null, this);
+    }
+
+    /**
+     * Builds the constant identity-pattern scaffold the parent {@code TreeLikelihood} requires, from
+     * the read-count taxa and site count plus the genotype datatype. The genotype values are dummy
+     * (only the taxa / site-count / datatype / pattern structure is used); a {@code MutableAlignment}
+     * keeps one pattern per site (no compression), which the per-site read-count mapping relies on.
+     */
+    private Alignment buildScaffold(DataType genotypeDataType) {
+        ReadCount rc = readCountModel.getReadCount();
+        String[] taxa = rc.getTaxaNames();
+        int nSites = rc.getSiteNumber();
+        String genoChar = genotypeDataType.getCharacter(0); // any valid genotype char; value ignored
+        StringBuilder sb = new StringBuilder(nSites);
+        for (int j = 0; j < nSites; j++) sb.append(genoChar);
+        String seqStr = sb.toString();
+
+        Alignment dense = new Alignment();
+        for (String taxon : taxa) {
+            dense.setInputValue("sequence", new Sequence(taxon.trim(), seqStr));
+        }
+        dense.setInputValue("userDataType", genotypeDataType);
+        dense.initAndValidate();
+
+        MutableAlignment scaffold = new MutableAlignment(dense);
+        scaffold.setID("readCountScaffold");
+        scaffold.initAndValidate();
+        return scaffold;
+    }
+
+    /**
+     * Tip partial vector for one leaf: for each site (== pattern, identity), the per-genotype
+     * read-count likelihood, max-normalised per site. Accumulates the per-site log-max into
+     * {@link #globalLogOffset}.
+     */
+    @Override
+    protected double[] getLeafPartials(Node node) {
+        Alignment data = dataInput.get();
+        int nrOfStates = data.getDataType().getStateCount();
+        int nrOfPatterns = data.getPatternCount();
+        double[] partials = new double[nrOfPatterns * nrOfStates];
+
+        int alignIdx = getTaxonIndex(node.getID(), data);
+        int rcIdx = alignToRC[alignIdx];
+
+        double[] logRC = new double[nrOfStates];
+        int i = 0;
+        for (int p = 0; p < nrOfPatterns; p++) {
+            int[] reads = readCountModel.getReadCount().getReadCounts(rcIdx, p);
+            int coverage = readCountModel.getCoverage(alignIdx, p);
+            double max = Double.NEGATIVE_INFINITY;
+            for (int g = 0; g < nrOfStates; g++) {
+                logRC[g] = readCountModel.logLiklihoodRC(g, reads, coverage, rcIdx);
+                if (logRC[g] > max) max = logRC[g];
+            }
+            globalLogOffset += max;
+            for (int g = 0; g < nrOfStates; g++) {
+                partials[i++] = Math.exp(logRC[g] - max);
+            }
+        }
+        return partials;
+    }
+
+    /**
+     * Rebuild and re-upload every leaf's partials from the current read-count parameters,
+     * recomputing globalLogOffset from scratch.
+     */
+    @Override
+    public void updateLeafPartials() {
+        globalLogOffset = 0.0;
+        readCountModel.initialize();
+        List<Node> leaves = treeInput.get().getExternalNodes();
+        for (Node node : leaves) {
+            int nodeId = node.getNr();
+            likelihoodCore.setNodePartialsForUpdate(nodeId);
+            BeerLikelihoodCore beer = (BeerLikelihoodCore) likelihoodCore;
+            beer.setCurrentNodePartials(nodeId, getLeafPartials(node));
+        }
+    }
+
+    @Override
+    public double calculateLogP() {
+        // super (Fast) re-runs updateLeafPartials() when the leaf-partial dirty flag is set,
+        // which resets and re-accumulates globalLogOffset; otherwise globalLogOffset is unchanged.
+        double core = super.calculateLogP();
+        logP = core + globalLogOffset;
+        return logP;
+    }
+
+    @Override
+    protected boolean requiresRecalculation() {
+        // any read-count parameter change invalidates the tip partials -> full rebuild
+        for (StateNode p : rcParams) {
+            if (p != null && p.somethingIsDirty()) {
+                updateLeafPartials = true;
+                hasDirt = Tree.IS_FILTHY;
+                return true;
+            }
+        }
+        // otherwise defer to the inherited tree / siteModel / branchRate / data checks
+        return super.requiresRecalculation();
+    }
+
+    @Override
+    public void store() {
+        storedGlobalLogOffset = globalLogOffset;
+        super.store();
+    }
+
+    @Override
+    public void restore() {
+        globalLogOffset = storedGlobalLogOffset;
+        super.restore();
+    }
+}

--- a/phylonco-beast/src/main/java/phylonco/beast/evolution/likelihood/SampledGenotypeLogger.java
+++ b/phylonco-beast/src/main/java/phylonco/beast/evolution/likelihood/SampledGenotypeLogger.java
@@ -1,0 +1,260 @@
+package phylonco.beast.evolution.likelihood;
+
+import beast.base.core.BEASTObject;
+import beast.base.core.Description;
+import beast.base.core.Input;
+import beast.base.core.Loggable;
+import beast.base.evolution.branchratemodel.BranchRateModel;
+import beast.base.evolution.datatype.DataType;
+import beast.base.evolution.sitemodel.SiteModelInterface;
+import beast.base.evolution.substitutionmodel.SubstitutionModel;
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beast.base.util.Randomizer;
+import phylonco.beast.evolution.datatype.ReadCount;
+import phylonco.beast.evolution.readcountmodel.LikelihoodReadCountModel;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+
+/**
+ * Logs a tree-aware sample of the per-cell genotype alignment when genotypes are integrated out by
+ * {@link ReadCountTreeLikelihood} (so there is no sampled MutableAlignment to log).
+ *
+ * <p>For each logged MCMC state it draws a joint genotype sample over the whole tree, exactly as
+ * {@code GibbsSiteOperator} (sampleAllSites) did: leaf partials are read-count likelihoods
+ * {@code P(reads | g)}, a Felsenstein up-pass computes internal partials per rate category, then a
+ * rate category and the root state are sampled and a pre-order down-pass samples every node's
+ * genotype. Sampling the ancestral (internal) states is what conditions the leaf genotypes on the
+ * tree; only the leaf genotypes are emitted here (one taxon-named column each), the direct analog
+ * of the old MutableAlignment log but now conditioned on the tree rather than read counts alone.</p>
+ */
+@Description("Tree-aware sample of per-cell genotypes (leaf states from a joint ancestral down-pass)")
+public class SampledGenotypeLogger extends BEASTObject implements Loggable {
+
+    final public Input<Tree> treeInput = new Input<>(
+            "tree", "phylogenetic tree", Input.Validate.REQUIRED);
+    final public Input<SiteModelInterface.Base> siteModelInput = new Input<>(
+            "siteModel", "site model containing the genotype substitution model", Input.Validate.REQUIRED);
+    final public Input<BranchRateModel> branchRateModelInput = new Input<>(
+            "branchRateModel", "branch rate model for relaxed clock (optional)", Input.Validate.OPTIONAL);
+    final public Input<LikelihoodReadCountModel> readCountModelInput = new Input<>(
+            "readCountModel", "read-count model supplying P(reads | genotype)", Input.Validate.REQUIRED);
+    final public Input<ReadCount> readCountInput = new Input<>(
+            "readCount", "read count data", Input.Validate.REQUIRED);
+
+    private Tree tree;
+    private SiteModelInterface.Base siteModel;
+    private SubstitutionModel substitutionModel;
+    private BranchRateModel branchRateModel;
+    private LikelihoodReadCountModel readCountModel;
+    private ReadCount readCount;
+    private DataType datatype;
+
+    private int numNodes;
+    private int numStates;
+    private int numSites;
+    private int numCategories;
+
+    private double[][][] partials;      // [category][node][state]
+    private int[] sampledStates;        // [node]
+    private double[] transitionMatrix;  // [state*state]
+    private double[] logProbs;          // [state]
+    private double[] categoryLogProbs;  // [category]
+    private double[] rootFrequencies;
+
+    // tree leaf nodeNr -> ReadCount row index
+    private int[] nodeNrToRCIndex;
+    // ReadCount row order for stable output: taxon name per column
+    private String[] rcTaxaNames;
+    // accumulates the sampled genotype string for each ReadCount taxon across sites
+    private char[][] sampledSeq;        // [rcTaxon][site]
+
+    @Override
+    public void initAndValidate() {
+        tree = treeInput.get();
+        siteModel = siteModelInput.get();
+        substitutionModel = siteModel.getSubstitutionModel();
+        branchRateModel = branchRateModelInput.get();
+        readCountModel = readCountModelInput.get();
+        readCount = readCountInput.get();
+        datatype = readCountModel.getDataType();
+
+        numStates = datatype.getStateCount();
+        numSites = readCount.getSiteNumber();
+        numNodes = tree.getNodeCount();
+        numCategories = siteModel.getCategoryCount();
+
+        rcTaxaNames = readCount.getTaxaNames();
+
+        // map each tree leaf (by taxon name) to its ReadCount row
+        nodeNrToRCIndex = new int[numNodes];
+        Arrays.fill(nodeNrToRCIndex, -1);
+        for (Node leaf : tree.getExternalNodes()) {
+            String name = leaf.getID();
+            int rcIdx = -1;
+            for (int j = 0; j < rcTaxaNames.length; j++) {
+                if (name.equals(rcTaxaNames[j].trim())) {
+                    rcIdx = j;
+                    break;
+                }
+            }
+            if (rcIdx == -1) {
+                throw new IllegalArgumentException("tree taxon " + name + " not found in ReadCount data");
+            }
+            nodeNrToRCIndex[leaf.getNr()] = rcIdx;
+        }
+
+        partials = new double[numCategories][numNodes][numStates];
+        sampledStates = new int[numNodes];
+        transitionMatrix = new double[numStates * numStates];
+        logProbs = new double[numStates];
+        categoryLogProbs = new double[numCategories];
+        sampledSeq = new char[rcTaxaNames.length][numSites];
+    }
+
+    @Override
+    public void init(PrintStream out) {
+        for (String name : rcTaxaNames) {
+            out.print("genotype(" + name.trim() + ")\t");
+        }
+    }
+
+    @Override
+    public void log(long sample, PrintStream out) {
+        // refresh the read-count caches from the current parameter values
+        readCountModel.initialize();
+        for (int site = 0; site < numSites; site++) {
+            sampleSite(site);
+        }
+        for (int t = 0; t < rcTaxaNames.length; t++) {
+            out.print(new String(sampledSeq[t]) + "\t");
+        }
+    }
+
+    /** Joint sample of all node genotypes at one site (ported from GibbsSiteOperator.sampleSite). */
+    private void sampleSite(int site) {
+        for (Node leaf : tree.getExternalNodes()) {
+            computeLeafPartial(leaf, site);
+        }
+        for (int cat = 0; cat < numCategories; cat++) {
+            computeInternalPartials(tree.getRoot(), cat);
+        }
+        int category = sampleCategoryAndRootState();
+        sampleDescendantStates(tree.getRoot(), category);
+
+        // record the leaf genotypes for this site
+        for (Node leaf : tree.getExternalNodes()) {
+            int rcIdx = nodeNrToRCIndex[leaf.getNr()];
+            sampledSeq[rcIdx][site] = datatype.getCharacter(sampledStates[leaf.getNr()]).charAt(0);
+        }
+    }
+
+    private void computeLeafPartial(Node node, int site) {
+        int nodeNr = node.getNr();
+        int rcIdx = nodeNrToRCIndex[nodeNr];
+        int[] counts = readCount.getReadCounts(rcIdx, site);
+        int coverage = 0;
+        for (int c : counts) coverage += c;
+        for (int g = 0; g < numStates; g++) {
+            double partial = Math.exp(readCountModel.logLiklihoodRC(g, counts, coverage, rcIdx));
+            for (int cat = 0; cat < numCategories; cat++) {
+                partials[cat][nodeNr][g] = partial;
+            }
+        }
+    }
+
+    private void computeInternalPartials(Node node, int category) {
+        if (node.isLeaf()) return;
+        for (int i = 0; i < node.getChildCount(); i++) {
+            computeInternalPartials(node.getChild(i), category);
+        }
+        int nodeNr = node.getNr();
+        Arrays.fill(partials[category][nodeNr], 1.0);
+        for (int childIdx = 0; childIdx < node.getChildCount(); childIdx++) {
+            Node child = node.getChild(childIdx);
+            int childNr = child.getNr();
+            getTransitionMatrix(child, category, transitionMatrix);
+            for (int parentState = 0; parentState < numStates; parentState++) {
+                double sum = 0.0;
+                for (int childState = 0; childState < numStates; childState++) {
+                    sum += transitionMatrix[parentState * numStates + childState]
+                            * partials[category][childNr][childState];
+                }
+                partials[category][nodeNr][parentState] *= sum;
+            }
+        }
+    }
+
+    private void getTransitionMatrix(Node node, int category, double[] matrix) {
+        double branchRate = (branchRateModel != null) ? branchRateModel.getRateForBranch(node) : 1.0;
+        double rate = branchRate * siteModel.getRateForCategory(category, node);
+        substitutionModel.getTransitionProbabilities(
+                node, node.getParent().getHeight(), node.getHeight(), rate, matrix);
+    }
+
+    private int sampleCategoryAndRootState() {
+        Node root = tree.getRoot();
+        int rootNr = root.getNr();
+        rootFrequencies = substitutionModel.getFrequencies();
+        double[] proportions = siteModel.getCategoryProportions(root);
+
+        double maxCatLogProb = Double.NEGATIVE_INFINITY;
+        for (int cat = 0; cat < numCategories; cat++) {
+            double marginal = 0.0;
+            for (int g = 0; g < numStates; g++) {
+                marginal += rootFrequencies[g] * partials[cat][rootNr][g];
+            }
+            categoryLogProbs[cat] = Math.log(proportions[cat]) + Math.log(marginal);
+            maxCatLogProb = Math.max(maxCatLogProb, categoryLogProbs[cat]);
+        }
+        int sampledCategory = sampleFromLogProbs(categoryLogProbs, numCategories, maxCatLogProb);
+
+        double maxLogProb = Double.NEGATIVE_INFINITY;
+        for (int g = 0; g < numStates; g++) {
+            logProbs[g] = Math.log(rootFrequencies[g]) + Math.log(partials[sampledCategory][rootNr][g]);
+            maxLogProb = Math.max(maxLogProb, logProbs[g]);
+        }
+        sampledStates[rootNr] = sampleFromLogProbs(logProbs, numStates, maxLogProb);
+        return sampledCategory;
+    }
+
+    private void sampleDescendantStates(Node node, int category) {
+        for (int childIdx = 0; childIdx < node.getChildCount(); childIdx++) {
+            Node child = node.getChild(childIdx);
+            int childNr = child.getNr();
+            int parentState = sampledStates[node.getNr()];
+            getTransitionMatrix(child, category, transitionMatrix);
+            double maxLogProb = Double.NEGATIVE_INFINITY;
+            for (int g = 0; g < numStates; g++) {
+                logProbs[g] = Math.log(transitionMatrix[parentState * numStates + g])
+                        + Math.log(partials[category][childNr][g]);
+                maxLogProb = Math.max(maxLogProb, logProbs[g]);
+            }
+            sampledStates[childNr] = sampleFromLogProbs(logProbs, numStates, maxLogProb);
+            if (!child.isLeaf()) {
+                sampleDescendantStates(child, category);
+            }
+        }
+    }
+
+    private int sampleFromLogProbs(double[] logProbsArr, int size, double maxLogProb) {
+        double sumExp = 0.0;
+        double[] probs = new double[size];
+        for (int i = 0; i < size; i++) {
+            probs[i] = Math.exp(logProbsArr[i] - maxLogProb);
+            sumExp += probs[i];
+        }
+        double rand = Randomizer.nextDouble() * sumExp;
+        double cumulative = 0.0;
+        for (int i = 0; i < size; i++) {
+            cumulative += probs[i];
+            if (rand < cumulative) return i;
+        }
+        return size - 1;
+    }
+
+    @Override
+    public void close(PrintStream out) {
+    }
+}

--- a/phylonco-beast/src/main/java/phylonco/beast/evolution/readcountmodel/LikelihoodReadCountModel.java
+++ b/phylonco-beast/src/main/java/phylonco/beast/evolution/readcountmodel/LikelihoodReadCountModel.java
@@ -23,7 +23,10 @@ import java.util.Random;
 
 public class LikelihoodReadCountModel extends Distribution {
 
-    public Input<Alignment> alignmentInput = new Input<>("alignment", "alignment");
+    public Input<Alignment> alignmentInput = new Input<>("alignment",
+            "optional genotype alignment; in the integrated model there is no genotype alignment and "
+            + "the scaffold (taxa, site count, genotype datatype) is derived from the read counts "
+            + "(datatype set via setDataType()) instead");
     public Input<ReadCount> readCountInput = new Input<>("readCount", "nucleotide read counts");
 
     // epsilon, allelic dropout, ... parameters
@@ -46,6 +49,8 @@ public class LikelihoodReadCountModel extends Distribution {
     private RealScalarParam w2;
     private Alignment alignment;
     private ReadCount readCount;
+    private int numTaxa;   // number of cells (from alignment, or from readCount when integrated)
+    private int numSites;  // number of sites (from alignment, or from readCount when integrated)
     private double[] negp1, negp2, negr1, negr2;
     private double[] wv;
     private double[][][] wPropensitiesLogGamma = new double[2][10][4];
@@ -138,15 +143,6 @@ public class LikelihoodReadCountModel extends Distribution {
 
     @Override
     public void initAndValidate() {
-        // fill genotype index table
-        // check data type is supported
-        datatype = alignmentInput.get().getDataType();
-        if (datatype instanceof NucleotideDiploid10) {
-            initGt10IndexTable();
-        } else if (datatype instanceof NucleotideDiploid16) {
-            initGt16IndexTable();
-        }
-        // checking parameters correct
         // get parameters
         epsilon = epsilonInput.get();
         delta = deltaInput.get();
@@ -158,29 +154,44 @@ public class LikelihoodReadCountModel extends Distribution {
         alignment = alignmentInput.get();
         readCount = readCountInput.get();
 
-        // Build mapping from alignment taxon index to ReadCount taxon index.
-        // The alignment and ReadCount may have taxa in different orders.
         String[] rcTaxaNames = readCount.getTaxaNames();
-        alignToRCIndex = new int[alignment.getTaxonCount()];
-        for (int i = 0; i < alignment.getTaxonCount(); i++) {
-            String alignTaxonName = alignment.getTaxaNames().get(i);
-            alignToRCIndex[i] = i; // default: identity mapping
-            for (int j = 0; j < rcTaxaNames.length; j++) {
-                if (alignTaxonName.equals(rcTaxaNames[j].trim())) {
-                    alignToRCIndex[i] = j;
-                    break;
+        if (alignment != null) {
+            // standalone use: scaffold comes from the genotype alignment
+            datatype = alignment.getDataType();
+            buildIndexTable();
+            numTaxa = alignment.getTaxonCount();
+            numSites = alignment.getSiteCount();
+            // Build mapping from alignment taxon index to ReadCount taxon index
+            // (the alignment and ReadCount may have taxa in different orders).
+            alignToRCIndex = new int[numTaxa];
+            for (int i = 0; i < numTaxa; i++) {
+                String alignTaxonName = alignment.getTaxaNames().get(i);
+                alignToRCIndex[i] = i; // default: identity mapping
+                for (int j = 0; j < rcTaxaNames.length; j++) {
+                    if (alignTaxonName.equals(rcTaxaNames[j].trim())) {
+                        alignToRCIndex[i] = j;
+                        break;
+                    }
                 }
             }
+        } else {
+            // integrated model: there is no genotype alignment, so the scaffold (cells, sites,
+            // taxon order) is the read-count data itself. The genotype datatype is supplied later
+            // via setDataType() (from the GT10/GT16 substitution model in ReadCountTreeLikelihood).
+            numTaxa = rcTaxaNames.length;
+            numSites = readCount.getSiteNumber();
+            alignToRCIndex = new int[numTaxa];
+            for (int i = 0; i < numTaxa; i++) alignToRCIndex[i] = i; // identity
         }
 
         negp1 = new double[s.size()];
         negp2 = new double[s.size()];
         negr1 = new double[s.size()];
         negr2 = new double[s.size()];
-        coverages = new int[alignment.getTaxonCount()][alignment.getSiteCount()];
-        for (int i = 0; i < alignment.getTaxonCount(); i++) {
+        coverages = new int[numTaxa][numSites];
+        for (int i = 0; i < numTaxa; i++) {
             int rcIdx = alignToRCIndex[i];
-            for (int j = 0; j < alignment.getSiteCount(); j++) {
+            for (int j = 0; j < numSites; j++) {
                 for (int k = 0; k < 4; k++) {
                     coverages[i][j] += readCount.getReadCounts(rcIdx,j)[k];
                     if (readCount.getReadCounts(rcIdx,j)[k] > maxReadCount) {
@@ -200,8 +211,8 @@ public class LikelihoodReadCountModel extends Distribution {
             readDepthLogGamma[i] = LogGamma.value(i);
         }
 
-        currentLogPi = new double[alignment.getTaxonCount()];
-        storedLogPi =  new double[alignment.getTaxonCount()];
+        currentLogPi = new double[numTaxa];
+        storedLogPi =  new double[numTaxa];
         rGammaLog = new double[2][s.size()];
         p1Log = new double[2][s.size()];
         p2Log = new double[2][s.size()];
@@ -210,14 +221,35 @@ public class LikelihoodReadCountModel extends Distribution {
         rc_wPropLogGamma = new double[2][maxReadCount+1][10][4];
     }
 
+    /** Builds the genotype-state -> nucleotide-pair propensity index table for the current datatype. */
+    private void buildIndexTable() {
+        if (datatype instanceof NucleotideDiploid10) {
+            initGt10IndexTable();
+        } else if (datatype instanceof NucleotideDiploid16) {
+            initGt16IndexTable();
+        }
+    }
+
+    /**
+     * Sets the genotype datatype when there is no genotype alignment (integrated model). Called by
+     * {@link phylonco.beast.evolution.likelihood.ReadCountTreeLikelihood} with the datatype implied
+     * by the GT10/GT16 substitution model, and builds the genotype index table.
+     */
+    public void setDataType(DataType dataType) {
+        this.datatype = dataType;
+        buildIndexTable();
+    }
+
     // calculate propensities matrix of dirichlet multinomial distribution(read count model)
     // and params of negative binomial distribution(coverage model)
     /**
      * Recompute cached values from current parameter values.
-     * Package-private so GibbsSiteOperator can ensure caches are fresh
-     * before sampling (they may be stale after a rejected parameter proposal).
+     * Public so GibbsSiteOperator can ensure caches are fresh before sampling
+     * (they may be stale after a rejected parameter proposal), and so
+     * ReadCountTreeLikelihood (a different package) can refresh the caches
+     * before reading per-genotype likelihoods to build tip partials.
      */
-    void initialize() {
+    public void initialize() {
         double mean1;
         double mean2;
         double variance1;
@@ -314,6 +346,21 @@ public class LikelihoodReadCountModel extends Distribution {
     /** Returns the mapping from alignment taxon index to ReadCount taxon index. */
     public int[] getAlignToRCIndex() {
         return alignToRCIndex;
+    }
+
+    /** Total read depth (summed over the 4 nucleotides) for an alignment taxon at a site. */
+    public int getCoverage(int taxonIndex, int site) {
+        return coverages[taxonIndex][site];
+    }
+
+    /** The ReadCount data backing this model. */
+    public ReadCount getReadCount() {
+        return readCount;
+    }
+
+    /** The genotype datatype (NucleotideDiploid16 or NucleotideDiploid10). */
+    public DataType getDataType() {
+        return datatype;
     }
 
     //Calculate the log likelihood of read count model by summarizing the log likelihood at each site

--- a/phylonco-beast/src/test/java/phylonco/beast/evolution/likelihood/ReadCountTreeLikelihoodTest.java
+++ b/phylonco-beast/src/test/java/phylonco/beast/evolution/likelihood/ReadCountTreeLikelihoodTest.java
@@ -1,0 +1,303 @@
+package phylonco.beast.evolution.likelihood;
+
+import beast.base.evolution.alignment.Alignment;
+import beast.base.evolution.alignment.Sequence;
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.TreeParser;
+import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.evolution.sitemodel.SiteModel;
+import beast.base.spec.evolution.substitutionmodel.Frequencies;
+import beast.base.spec.inference.parameter.RealScalarParam;
+import beast.base.spec.inference.parameter.RealVectorParam;
+import beast.base.spec.inference.parameter.SimplexParam;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import phylonco.beast.evolution.datatype.ReadCount;
+import phylonco.beast.evolution.readcountmodel.LikelihoodReadCountModel;
+import phylonco.beast.evolution.substitutionmodel.GT10;
+
+import java.util.Arrays;
+
+import static beast.pkgmgmt.BEASTClassLoader.addServices;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Validates that {@link ReadCountTreeLikelihood} (which integrates the latent genotypes out via
+ * read-count tip partials) equals a hand-computed Felsenstein integral over genotypes that uses
+ * the same per-genotype read-count likelihoods. This cross-checks the partials wiring into the
+ * Beer likelihood core: genotype state ordering, branch direction, root frequencies as the
+ * genotype prior, and the per-(tip,site) offset bookkeeping.
+ */
+public class ReadCountTreeLikelihoodTest {
+
+    private static final double DELTA = 1e-9;
+    private static final int N = 10; // GT10 genotype states
+
+    // taxa "a", "b"; tree (a:0.3, b:0.5)
+    private static final double BRANCH_A = 0.3;
+    private static final double BRANCH_B = 0.5;
+
+    // read-count model parameters
+    private static final String EPSILON = "0.06";
+    private static final String DELTA_DROPOUT = "0.5";
+    private static final String T_PARAM = "9.996182050184155";
+    private static final String V_PARAM = "1.0670434040009762";
+    private static final double[] S_PARAM = {1.0399635911708527, 1.0419228814287969};
+    private static final String W1 = "100.0";
+    private static final String W2 = "2.0";
+
+    @BeforeClass
+    public static void setUpClass() {
+        addServices("version.xml");
+    }
+
+    /** Builds the GT10 substitution + site model with uniform frequencies and fixed nuc rates. */
+    private SiteModel buildSiteModel() {
+        double[] piVals = new double[N];
+        Arrays.fill(piVals, 1.0 / N);
+        SimplexParam pi = new SimplexParam(piVals);
+        Frequencies freqs = new Frequencies();
+        freqs.initByName("frequencies", pi, "estimate", false);
+        freqs.initAndValidate();
+
+        RealVectorParam nucRates = new RealVectorParam(
+                new double[]{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, PositiveReal.INSTANCE);
+        nucRates.setInputValue("keys", "AC AG AT CG CT GT");
+        nucRates.initAndValidate();
+
+        GT10 subsModel = new GT10();
+        subsModel.initByName("nucRates", nucRates, "frequencies", freqs);
+        subsModel.initAndValidate();
+
+        SiteModel siteModel = new SiteModel();
+        siteModel.initByName(
+                "mutationRate", new RealScalarParam(1.0, PositiveReal.INSTANCE),
+                "gammaCategoryCount", 1, "substModel", subsModel);
+        siteModel.initAndValidate();
+        return siteModel;
+    }
+
+    /** Constant scaffold alignment: GT10 datatype, taxa a/b, distinct columns so patterns==sites. */
+    private Alignment buildScaffold(int nSites) {
+        // "AC" -> sites (AA, CC); "GT" -> sites (GG, TT): distinct columns per site, no compression
+        Alignment data = new Alignment();
+        data.initByName(
+                "sequence", new Sequence("a", "AC".substring(0, nSites)),
+                "sequence", new Sequence("b", "GT".substring(0, nSites)),
+                "dataType", "nucleotideDiploid10");
+        return data;
+    }
+
+    /** A positive-real scalar parameter from a decimal string (spec params no longer auto-convert Strings). */
+    private static RealScalarParam scalar(String value) {
+        return new RealScalarParam(Double.parseDouble(value), PositiveReal.INSTANCE);
+    }
+
+    private LikelihoodReadCountModel buildReadCountModel(Alignment scaffold, String readCountStr) {
+        ReadCount readCount = new ReadCount();
+        readCount.initByName("value", readCountStr, "taxaNames", "a b");
+
+        LikelihoodReadCountModel rcm = new LikelihoodReadCountModel();
+        rcm.initByName(
+                "alignment", scaffold,
+                "readCount", readCount,
+                "epsilon", scalar(EPSILON),
+                "delta", scalar(DELTA_DROPOUT),
+                "t", scalar(T_PARAM),
+                "v", scalar(V_PARAM),
+                "s", new RealVectorParam(S_PARAM, PositiveReal.INSTANCE),
+                "w1", scalar(W1),
+                "w2", scalar(W2));
+        return rcm;
+    }
+
+    private ReadCountTreeLikelihood buildLikelihood(Alignment scaffold, LikelihoodReadCountModel rcm,
+                                                    SiteModel siteModel, TreeParser tree) {
+        ReadCountTreeLikelihood likelihood = new ReadCountTreeLikelihood();
+        likelihood.initByName(
+                "data", scaffold,
+                "tree", tree,
+                "siteModel", siteModel,
+                "readCountModel", rcm);
+        return likelihood;
+    }
+
+    private TreeParser buildTree(Alignment scaffold) {
+        TreeParser tree = new TreeParser();
+        tree.initByName("taxa", scaffold, "newick", "(a:" + BRANCH_A + ", b:" + BRANCH_B + ");",
+                "IsLabelledNewick", true);
+        return tree;
+    }
+
+    /**
+     * Hand Felsenstein reference, done per-site in log space with the same max-offset trick the
+     * implementation uses, so it is both the ground truth and numerically robust under underflow.
+     */
+    private double referenceLogP(Alignment scaffold, LikelihoodReadCountModel rcm,
+                                 SiteModel siteModel, TreeParser tree, int nSites) {
+        rcm.initialize();
+        GT10 subs = (GT10) siteModel.substModelInput.get();
+        double[] freq = subs.getFrequencies();
+        int[] a2rc = rcm.getAlignToRCIndex();
+
+        Node nodeA = nodeOf(tree, "a");
+        Node nodeB = nodeOf(tree, "b");
+        // use the branch lengths BEAST actually assigned (robust to non-ultrametric height resolution)
+        double[] Pa = transitionMatrix(subs, nodeA, nodeA.getLength());
+        double[] Pb = transitionMatrix(subs, nodeB, nodeB.getLength());
+
+        int alignA = scaffold.getTaxonIndex("a");
+        int alignB = scaffold.getTaxonIndex("b");
+
+        double logRef = 0.0;
+        for (int j = 0; j < nSites; j++) {
+            double[] logA = perGenotypeLog(rcm, alignA, a2rc[alignA], j);
+            double[] logB = perGenotypeLog(rcm, alignB, a2rc[alignB], j);
+            double offA = max(logA);
+            double offB = max(logB);
+            double[] La = scaledExp(logA, offA);
+            double[] Lb = scaledExp(logB, offB);
+
+            double Lj = 0.0;
+            for (int r = 0; r < N; r++) {
+                double sa = 0.0, sb = 0.0;
+                for (int g = 0; g < N; g++) {
+                    sa += Pa[r * N + g] * La[g];
+                    sb += Pb[r * N + g] * Lb[g];
+                }
+                Lj += freq[r] * sa * sb;
+            }
+            logRef += Math.log(Lj) + offA + offB;
+        }
+        return logRef;
+    }
+
+    private double[] perGenotypeLog(LikelihoodReadCountModel rcm, int alignIdx, int rcIdx, int site) {
+        int[] reads = rcm.getReadCount().getReadCounts(rcIdx, site);
+        int coverage = rcm.getCoverage(alignIdx, site);
+        double[] out = new double[N];
+        for (int g = 0; g < N; g++) out[g] = rcm.logLiklihoodRC(g, reads, coverage, rcIdx);
+        return out;
+    }
+
+    private double[] transitionMatrix(GT10 subs, Node node, double branchLen) {
+        double[] mat = new double[N * N];
+        subs.getTransitionProbabilities(node, branchLen, 0.0, 1.0, mat);
+        return mat;
+    }
+
+    private Node nodeOf(TreeParser tree, String id) {
+        for (Node n : tree.getExternalNodes()) if (id.equals(n.getID())) return n;
+        throw new RuntimeException("no node " + id);
+    }
+
+    private static double max(double[] x) {
+        double m = Double.NEGATIVE_INFINITY;
+        for (double v : x) if (v > m) m = v;
+        return m;
+    }
+
+    private static double[] scaledExp(double[] log, double off) {
+        double[] out = new double[log.length];
+        for (int i = 0; i < log.length; i++) out[i] = Math.exp(log[i] - off);
+        return out;
+    }
+
+    /** Core: 2 taxa x 2 sites, GT10. Integrated likelihood == hand Felsenstein integral. */
+    @Test
+    public void testIntegratedEqualsBruteForceTwoSite() {
+        int nSites = 2;
+        // a: site0 / site1 ; b: site0 / site1   (A:C:G:T per site, sites separated by ",")
+        String readCountStr = "3:0:1:8,0:12:2:0\n7:1:0:4,0:1:9:1";
+        Alignment scaffold = buildScaffold(nSites);
+        LikelihoodReadCountModel rcm = buildReadCountModel(scaffold, readCountStr);
+        SiteModel siteModel = buildSiteModel();
+        TreeParser tree = buildTree(scaffold);
+
+        ReadCountTreeLikelihood likelihood = buildLikelihood(scaffold, rcm, siteModel, tree);
+
+        double logP = likelihood.calculateLogP();
+        double logRef = referenceLogP(scaffold, rcm, siteModel, tree, nSites);
+        assertEquals(logRef, logP, DELTA);
+    }
+
+    /** Underflow: a very-high-coverage site makes raw read-count likelihoods strongly negative;
+     *  the integrated result must still match the (offset-robust) reference exactly. */
+    @Test
+    public void testUnderflowHighCoverage() {
+        int nSites = 1;
+        // coverage ~300 at one site for each cell
+        String readCountStr = "120:5:170:5\n3:150:7:140";
+        Alignment scaffold = buildScaffold(nSites);
+        LikelihoodReadCountModel rcm = buildReadCountModel(scaffold, readCountStr);
+        SiteModel siteModel = buildSiteModel();
+        TreeParser tree = buildTree(scaffold);
+
+        ReadCountTreeLikelihood likelihood = buildLikelihood(scaffold, rcm, siteModel, tree);
+
+        double logP = likelihood.calculateLogP();
+        double logRef = referenceLogP(scaffold, rcm, siteModel, tree, nSites);
+        assertEquals(logRef, logP, DELTA);
+        // sanity: a real (finite) number, not -Inf/NaN
+        assertTrue(Double.isFinite(logP));
+    }
+
+    /** Stale-cache guard (must-fix #1): perturbing a read-count param then restoring it must
+     *  return exactly the original logP — proves initialize() is refreshed on every rebuild. */
+    @Test
+    public void testParamRoundTripConsistency() {
+        int nSites = 2;
+        String readCountStr = "3:0:1:8,0:12:2:0\n7:1:0:4,0:1:9:1";
+        Alignment scaffold = buildScaffold(nSites);
+        LikelihoodReadCountModel rcm = buildReadCountModel(scaffold, readCountStr);
+        SiteModel siteModel = buildSiteModel();
+        TreeParser tree = buildTree(scaffold);
+
+        ReadCountTreeLikelihood likelihood = buildLikelihood(scaffold, rcm, siteModel, tree);
+        RealScalarParam epsilon = rcm.epsilonInput.get();
+
+        double logP0 = likelihood.calculateLogP();
+
+        epsilon.set(0.2);
+        likelihood.requiresRecalculation();
+        double logP1 = likelihood.calculateLogP();
+        assertNotEquals(logP0, logP1, DELTA); // the move actually changed something
+
+        epsilon.set(Double.parseDouble(EPSILON));
+        likelihood.requiresRecalculation();
+        double logP2 = likelihood.calculateLogP();
+        assertEquals(logP0, logP2, DELTA);
+    }
+
+    /** store()/restore() of globalLogOffset (must-fix #3): after store, a param change, then
+     *  restore (with the param reverted), a fresh logP must equal the pre-move value. */
+    @Test
+    public void testStoreRestoreOffset() {
+        int nSites = 2;
+        String readCountStr = "3:0:1:8,0:12:2:0\n7:1:0:4,0:1:9:1";
+        Alignment scaffold = buildScaffold(nSites);
+        LikelihoodReadCountModel rcm = buildReadCountModel(scaffold, readCountStr);
+        SiteModel siteModel = buildSiteModel();
+        TreeParser tree = buildTree(scaffold);
+
+        ReadCountTreeLikelihood likelihood = buildLikelihood(scaffold, rcm, siteModel, tree);
+        RealScalarParam epsilon = rcm.epsilonInput.get();
+
+        double logP0 = likelihood.calculateLogP();
+
+        likelihood.store();
+        rcm.store();
+        epsilon.set(0.2);
+        likelihood.requiresRecalculation();
+        likelihood.calculateLogP();
+
+        // reject: revert param and restore the calculation nodes
+        epsilon.set(Double.parseDouble(EPSILON));
+        likelihood.restore();
+        rcm.restore();
+        double logP2 = likelihood.calculateLogP();
+        assertEquals(logP0, logP2, DELTA);
+    }
+}

--- a/phylonco-beast/src/test/java/phylonco/beast/evolution/readcountmodel/LikelihoodReadCountModelTest.java
+++ b/phylonco-beast/src/test/java/phylonco/beast/evolution/readcountmodel/LikelihoodReadCountModelTest.java
@@ -4,6 +4,7 @@ import beast.base.evolution.alignment.Alignment;
 
 import beast.base.parser.NexusParser;
 import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.inference.parameter.RealScalarParam;
 import beast.base.spec.inference.parameter.RealVectorParam;
 import beast.pkgmgmt.BEASTClassLoader;
 import org.junit.Before;
@@ -74,13 +75,13 @@ public class LikelihoodReadCountModelTest {
         // TODO: update unit tests to be type safe
         likelihoodReadCountModel.setInputValue("alignment", alignment);
         likelihoodReadCountModel.setInputValue("readCount", readCounts);
-        likelihoodReadCountModel.setInputValue("epsilon", epsilon.toString());
-        likelihoodReadCountModel.setInputValue("delta", delta.toString());
-        likelihoodReadCountModel.setInputValue("t", t.toString());
-        likelihoodReadCountModel.setInputValue("v", v.toString());
-        likelihoodReadCountModel.setInputValue("s", sParam);
-        likelihoodReadCountModel.setInputValue("w1", w1.toString());
-        likelihoodReadCountModel.setInputValue("w2", w2.toString());
+        likelihoodReadCountModel.setInputValue("epsilon", new RealScalarParam(epsilon, PositiveReal.INSTANCE));
+        likelihoodReadCountModel.setInputValue("delta", new RealScalarParam(delta, PositiveReal.INSTANCE));
+        likelihoodReadCountModel.setInputValue("t", new RealScalarParam(t, PositiveReal.INSTANCE));
+        likelihoodReadCountModel.setInputValue("v", new RealScalarParam(v, PositiveReal.INSTANCE));
+        likelihoodReadCountModel.setInputValue("s", new RealVectorParam<>(s, PositiveReal.INSTANCE));
+        likelihoodReadCountModel.setInputValue("w1", new RealScalarParam(w1, PositiveReal.INSTANCE));
+        likelihoodReadCountModel.setInputValue("w2", new RealScalarParam(w2, PositiveReal.INSTANCE));
 
         // ...
 

--- a/phylonco-beast/version.xml
+++ b/phylonco-beast/version.xml
@@ -26,6 +26,8 @@
         <provider classname="phylonco.beast.evolution.likelihood.TreeLikelihoodWithError"/>
         <provider classname="phylonco.beast.evolution.likelihood.TreeLikelihoodWithErrorFast"/>
         <provider classname="phylonco.beast.evolution.likelihood.TreeLikelihoodWithErrorSlow"/>
+        <provider classname="phylonco.beast.evolution.likelihood.ReadCountTreeLikelihood"/>
+        <provider classname="phylonco.beast.evolution.likelihood.SampledGenotypeLogger"/>
         <provider classname="phylonco.beast.evolution.substitutionmodel.BinarySubstitutionModel"/>
         <provider classname="phylonco.beast.evolution.substitutionmodel.GT16"/>
         <provider classname="phylonco.beast.evolution.substitutionmodel.GT10"/>

--- a/phylonco-lphy/src/main/java/phylonco/lphy/evolution/readcountmodel/ReadCountDataFilter.java
+++ b/phylonco-lphy/src/main/java/phylonco/lphy/evolution/readcountmodel/ReadCountDataFilter.java
@@ -18,13 +18,13 @@ public class ReadCountDataFilter extends DeterministicFunction<ReadCountData> {
     private double wa;
     private double lambda;
     private double threshold;
-    private Value<ReadCountData> readCountData; ;
+    private Value<ReadCountData> readCountData;
     public ReadCountDataFilter(
             @ParameterInfo(name = "rc", narrativeName = "read count data", description = "read count data which used to filter variable sites.") Value<ReadCountData> readCountData,
-            @ParameterInfo(name = "fw", narrativeName = "expected frequence of alternative nucleotide", description = "the expected frequence of alternative nucleotide in beta-binomial distribution, by default is 0.001", optional = true) Value<Double> fw,
+            @ParameterInfo(name = "fw", narrativeName = "expected sequencing error", description = "the expected sequencing error in beta-binomial distribution, by default is 0.001", optional = true) Value<Double> fw,
             @ParameterInfo(name = "ww", narrativeName = "shape parameter of homozygous genotype(wild type)", description = "shape parameter of homozygous genotype in beta-binomial distribution, by default is 1.0", optional = true) Value<Double> ww,
             @ParameterInfo(name = "wa", narrativeName = "shape parameter of heterozygous genotype(mutant type)", description = "shape parameter of heterozygous genotype in beta-binomial distribution, by default is 2.0", optional = true) Value<Double> wa,
-            @ParameterInfo(name = "lambda", narrativeName = "prior probability of mutation", description = "prior probability of a mutation occurring at a locus, by default is 0.001", optional = true) Value<Double> lambda,
+            @ParameterInfo(name = "lambda", narrativeName = "prior probability of mutation", description = "prior probability of a mutation occurring at a locus, by default is 0.0001", optional = true) Value<Double> lambda,
             @ParameterInfo(name = "threshold", narrativeName = "threshold", description = "threshold for determining candidate status, by default is 0.95", optional = true) Value<Double> threshold) {
         this.readCountData = readCountData;
         if (fw != null) {
@@ -48,7 +48,7 @@ public class ReadCountDataFilter extends DeterministicFunction<ReadCountData> {
         if (lambda != null) {
             this.lambda = lambda.value();
         } else {
-            this.lambda = 0.004;
+            this.lambda = 0.0001;
         }
 
         if (threshold != null) {

--- a/phylonco-lphy/src/main/java/phylonco/lphy/evolution/readcountmodel/ReadCountDataSubset.java
+++ b/phylonco-lphy/src/main/java/phylonco/lphy/evolution/readcountmodel/ReadCountDataSubset.java
@@ -1,0 +1,53 @@
+package phylonco.lphy.evolution.readcountmodel;
+
+import lphy.core.model.DeterministicFunction;
+import lphy.core.model.Value;
+import lphy.core.model.annotation.GeneratorInfo;
+import lphy.core.model.annotation.ParameterInfo;
+
+import java.util.Arrays;
+
+public class ReadCountDataSubset extends DeterministicFunction<ReadCountData> {
+    private int startSite;
+    private int endSite;
+    private Value<ReadCountData> readCountData;
+
+
+    public ReadCountDataSubset(
+            @ParameterInfo(name = "rc", narrativeName = "read count data", description = "input data read count.") Value<ReadCountData> readCountData,
+            @ParameterInfo(name = "start", narrativeName = "start site index", description = "the start site index to extra data") Value<Integer> startSite,
+            @ParameterInfo(name = "end", narrativeName = "end site index", description = "the start site index to extra data") Value<Integer> endSite) {
+        if (readCountData == null) {
+            throw new IllegalArgumentException("readCount cannot be null");
+        }
+        if (startSite == null) {
+            throw new IllegalArgumentException("start site cannot be null");
+        }
+        if (endSite == null) {
+            throw new IllegalArgumentException("end site cannot be null");
+        }
+        this.readCountData = readCountData;
+        this.startSite = startSite.value();
+        this.endSite = endSite.value();
+    }
+
+    @GeneratorInfo(name="readCountDataSubset",
+            narrativeName = "read count data subset",
+            description = "get a read count data subset by 2 site indexes.")
+
+    @Override
+    public Value<ReadCountData> apply() {
+        ReadCountData rc = readCountData.value();
+        String[] chrom = Arrays.copyOfRange(rc.getChromNames(), startSite, endSite+1);
+        int[] ref = Arrays.copyOfRange(rc.getRefIndex(), startSite, endSite+1);
+        int[] site = Arrays.copyOfRange(rc.getSitesIndex(), startSite, endSite+1);
+        ReadCount[][] readCountDataMatrix = new ReadCount[rc.getTaxa().getDimension()][ref.length];
+        for (int i = 0; i < rc.getTaxa().getDimension(); i++) {
+            for (int j = 0; j < ref.length; j++) {
+                readCountDataMatrix[i][j] = rc.getReadCountDataMatrix()[i][startSite+j];
+            }
+        }
+        ReadCountData subsetReadCountData = new ReadCountData(chrom, ref, rc.getTaxa(), readCountDataMatrix, site);
+        return new Value<>(null, subsetReadCountData, this);
+    }
+}

--- a/phylonco-lphy/src/main/java/phylonco/lphy/spi/PhyloncoImpl.java
+++ b/phylonco-lphy/src/main/java/phylonco/lphy/spi/PhyloncoImpl.java
@@ -56,7 +56,7 @@ public class PhyloncoImpl extends LPhyBaseImpl {
                 CopyNumberBD.class,
                 ReadCopyProfile.class,
                 ReadTaxaReadCountMatrix.class,
-                ReadCountDataFilter.class,
+                ReadCountDataFilter.class, ReadCountDataSubset.class,
                 CopyReadCount.class, ReadCountToNexus.class, ReadReadCountNexus.class,
                 MpileupToReadCount.class
         );

--- a/phylonco-lphybeast/lphybeast.version.xml
+++ b/phylonco-lphybeast/lphybeast.version.xml
@@ -1,0 +1,17 @@
+<package name='lphybeast' version='2.0.0'>
+    <!-- Registers the lphybeast core SPI services so LPhyBeast can run headlessly without the
+         lphybeast BEAST package being installed in the BEAST package directory. Reconstructed from
+         the lphybeast jar's module-info `provides` clauses. -->
+    <service type="lphybeast.spi.LPhyBEASTMapping">
+        <provider classname="lphybeast.spi.LPhyBEASTMappingImpl"/>
+    </service>
+    <service type="lphybeast.spi.MCMCStrategy">
+        <provider classname="lphybeast.spi.DefaultMCMCStrategy"/>
+    </service>
+    <service type="lphybeast.spi.TreeLikelihoodStrategy">
+        <provider classname="lphybeast.spi.DefaultTreeLikelihoodStrategy"/>
+    </service>
+    <service type="lphybeast.spi.AlignmentHandler">
+        <provider classname="lphybeast.spi.DefaultAlignmentHandler"/>
+    </service>
+</package>

--- a/phylonco-lphybeast/pom.xml
+++ b/phylonco-lphybeast/pom.xml
@@ -41,6 +41,17 @@
             <version>${flc.version}</version>
         </dependency>
 
+        <!-- MutableAlignment is used at runtime by ReadCountTreeLikelihood (in phylonco-beast) to
+             build its internal identity-pattern scaffold; phylonco-beast's system-scoped dep is not
+             transitive (relative systemPath), so declare it here for the runtime/test classpath. -->
+        <dependency>
+            <groupId>beast2</groupId>
+            <artifactId>MutableAlignment</artifactId>
+            <version>0.0.2</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../phylonco-beast/lib/MutableAlignment-0.0.2.jar</systemPath>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/phylonco-lphybeast/src/main/java/module-info.java
+++ b/phylonco-lphybeast/src/main/java/module-info.java
@@ -5,6 +5,7 @@ open module phylonco.lphybeast {
     requires beast.base;
     requires lphy.base;
     requires flc;
+    requires beast.pkgmgmt;
 
     exports phylonco.lphybeast.spi;
     exports phylonco.lphybeast.tobeast.generators;

--- a/phylonco-lphybeast/src/main/java/phylonco/lphybeast/spi/LBPhylonco.java
+++ b/phylonco-lphybeast/src/main/java/phylonco/lphybeast/spi/LBPhylonco.java
@@ -83,7 +83,8 @@ public class LBPhylonco implements LPhyBEASTMapping {
                 ReadCopyProfile.class,
                 ReadCountDataFilter.class,
                 MpileupToReadCount.class,
-                ReadCountToNexus.class
+                ReadCountToNexus.class,
+                ReadCountDataSubset.class
         );
     }
 

--- a/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/GT10ToBEAST.java
+++ b/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/GT10ToBEAST.java
@@ -17,6 +17,7 @@ import lphybeast.GeneratorToBEAST;
 import phylonco.lphy.evolution.substitutionmodel.GT10;
 
 import beast.base.spec.type.Simplex;
+import beast.base.spec.inference.parameter.RealVectorParam;
 import beast.base.spec.evolution.substitutionmodel.Frequencies;
 
 import java.util.ArrayList;
@@ -37,14 +38,11 @@ public class GT10ToBEAST implements GeneratorToBEAST<GT10, phylonco.beast.evolut
         Value<Double[]> rates = gt10.getRates();
         Value<Double[]> freqs = gt10.getFreq();
 
-        RealParameter ratesParameter = (RealParameter)context.getBEASTObject(rates);
+        // beast3: getBEASTObject returns the spec param produced for the LPhy value
+        // (a Dirichlet rates vector -> SimplexParam, which is a RealVectorParam).
+        RealVectorParam ratesParameter = (RealVectorParam) context.getBEASTObject(rates);
         ratesParameter.setInputValue("keys", "AC AG AT CG CT GT");
         ratesParameter.initAndValidate();
-
-//        Frequencies freqsParameter = BEASTContext.createBEASTFrequencies(
-//                (RealParameter) context.getBEASTObject(freqs),
-//                "0 1 2 3 4 5 6 7 8 9");
-//        freqsParameter.initAndValidate();
 
         Frequencies freqsParameter = new Frequencies((Simplex) context.getBEASTObject(gt10.getFreq()));
 
@@ -53,8 +51,9 @@ public class GT10ToBEAST implements GeneratorToBEAST<GT10, phylonco.beast.evolut
 
         beastGT10.initAndValidate();
 
-        addAVMNOperator(freqsParameter.frequenciesInput.get(), context);
-        addAVMNOperator(ratesParameter, context);
+        // beast3 TODO: the custom AVMN operators on the spec Simplex rates/frequencies need the
+        // spec-package operators (the classic AVMN/Transform Function path can't take a Simplex).
+        // Until then, rely on LPhyBeast's default operator scheduling for these parameters.
 
         return beastGT10;
     }

--- a/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/GT16ToBEAST.java
+++ b/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/GT16ToBEAST.java
@@ -1,7 +1,7 @@
 package phylonco.lphybeast.tobeast.generators;
 
 import beast.base.core.BEASTInterface;
-import beast.base.evolution.substitutionmodel.Frequencies;
+import beast.base.spec.evolution.substitutionmodel.Frequencies;
 import beast.base.inference.operator.DeltaExchangeOperator;
 import beast.base.inference.operator.SwapOperator;
 import beast.base.inference.parameter.BooleanParameter;
@@ -43,13 +43,16 @@ public class GT16ToBEAST implements GeneratorToBEAST<GT16, phylonco.beast.evolut
         beastGT16.setInputValue("frequencies", freqsParameter);
         beastGT16.initAndValidate();
 
-        // set operators on frequency and rates
-        addDeltaExchangeOperator(freqsParameter.frequenciesInput.get(), context);
+        // set operator on rates (classic RealParameter from getBEASTObject)
         addDeltaExchangeOperator(ratesParameter, context);
 
-        // add extra operators
-        addExtraDeltaExchangeOperators(freqsParameter, context);
-        addExtraSwapOperators(freqsParameter, context);
+        // beast3 TODO: the frequencies are now a spec Simplex, which the classic
+        // DeltaExchangeOperator/SwapOperator (List<RealParameter>) cannot accept. The frequency
+        // delta-exchange/swap operators below need migrating to the spec-package operators before
+        // they can be re-enabled; until then GT16 frequencies are not operated on.
+        // addDeltaExchangeOperator(freqsParameter.frequenciesInput.get(), context);
+        // addExtraDeltaExchangeOperators(freqsParameter, context);
+        // addExtraSwapOperators(freqsParameter, context);
 
         return beastGT16;
     }

--- a/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/GTUnphaseToBEAST.java
+++ b/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/GTUnphaseToBEAST.java
@@ -3,6 +3,7 @@ package phylonco.lphybeast.tobeast.generators;
 import beast.base.core.BEASTInterface;
 import beast.base.evolution.likelihood.GenericTreeLikelihood;
 import beast.base.evolution.likelihood.ThreadedTreeLikelihood;
+import beast.base.inference.Distribution;
 import lphy.base.evolution.alignment.Alignment;
 import lphy.core.model.Generator;
 import lphy.core.model.GraphicalModelNode;
@@ -23,10 +24,13 @@ import java.util.List;
  * @author Kylie Chen
  * @author Yuan Xu
  */
-public class GTUnphaseToBEAST implements GeneratorToBEAST<UnphaseGenotypeAlignment, GenericTreeLikelihood>  {
+// beast3: phylonco's TreeLikelihoodWithError now extends the spec TreeLikelihood, which is NOT a
+// GenericTreeLikelihood, so the produced object is typed as the common supertype Distribution
+// (both TreeLikelihoodWithError and ThreadedTreeLikelihood are Distributions).
+public class GTUnphaseToBEAST implements GeneratorToBEAST<UnphaseGenotypeAlignment, Distribution>  {
 
     @Override
-    public GenericTreeLikelihood generatorToBEAST(UnphaseGenotypeAlignment generator, BEASTInterface value, BEASTContext context) {
+    public Distribution generatorToBEAST(UnphaseGenotypeAlignment generator, BEASTInterface value, BEASTContext context) {
 
         assert value instanceof beast.base.evolution.alignment.Alignment;
         beast.base.evolution.alignment.Alignment unphasedErrAlignment = (beast.base.evolution.alignment.Alignment)value;
@@ -42,7 +46,7 @@ public class GTUnphaseToBEAST implements GeneratorToBEAST<UnphaseGenotypeAlignme
             }
         }
 
-        GenericTreeLikelihood treeLikelihood = null;
+        Distribution treeLikelihood = null;
 
         // only cast if TreeLikelihoodWithError if using an error model
         if (context.getBEASTObject(errAligGenerator) instanceof TreeLikelihoodWithError) {
@@ -83,7 +87,7 @@ public class GTUnphaseToBEAST implements GeneratorToBEAST<UnphaseGenotypeAlignme
     }
 
     @Override
-    public Class<GenericTreeLikelihood> getBEASTClass() {
-        return GenericTreeLikelihood.class;
+    public Class<Distribution> getBEASTClass() {
+        return Distribution.class;
     }
 }

--- a/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/ReadCountModelToBEAST.java
+++ b/phylonco-lphybeast/src/main/java/phylonco/lphybeast/tobeast/generators/ReadCountModelToBEAST.java
@@ -1,71 +1,70 @@
 package phylonco.lphybeast.tobeast.generators;
 
 import beast.base.core.BEASTInterface;
-import beast.base.core.Function;
-import beast.base.evolution.operator.kernel.AdaptableVarianceMultivariateNormalOperator;
-import beast.base.inference.StateNode;
-import beast.base.inference.operator.UpDownOperator;
-import beast.base.inference.operator.kernel.Transform;
-import beast.base.inference.parameter.RealParameter;
+import beast.base.evolution.branchratemodel.BranchRateModel;
+import beast.base.spec.evolution.sitemodel.SiteModel;
+import beast.base.evolution.tree.Tree;
 import lphy.base.evolution.likelihood.PhyloCTMC;
 import lphy.core.model.Value;
 import lphybeast.BEASTContext;
 import lphybeast.GeneratorToBEAST;
-import mutablealignment.MATreeLikelihood;
-import mutablealignment.MutableAlignment;
+import lphybeast.tobeast.generators.PhyloCTMCToBEAST;
 import phylonco.beast.evolution.datatype.ReadCount;
-import phylonco.beast.evolution.readcountmodel.GibbsAlignmentOperator;
-import phylonco.beast.evolution.readcountmodel.GibbsSequenceOperator;
+import phylonco.beast.evolution.likelihood.ReadCountTreeLikelihood;
+import phylonco.beast.evolution.likelihood.SampledGenotypeLogger;
 import phylonco.beast.evolution.readcountmodel.LikelihoodReadCountModel;
-import mutablealignment.MutableAlignmentOperator;
 import phylonco.lphy.evolution.readcountmodel.ReadCountModel;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public class ReadCountModelToBEAST implements GeneratorToBEAST<ReadCountModel, LikelihoodReadCountModel> {
+/**
+ * Translates an LPhy {@code r ~ ReadCountModel(D=A, ...)} into the integrated-genotype BEAST model:
+ * the latent genotype alignment {@code A} is integrated out analytically via read-count tip partials
+ * rather than sampled. The single posterior factor is a {@link ReadCountTreeLikelihood} (the genotype
+ * tree likelihood with read-count tip partials); the {@link LikelihoodReadCountModel} is wired in only
+ * as its per-genotype-likelihood helper (NOT a separate factor). The original
+ * {@code mutablealignment.MATreeLikelihood} is removed and no genotype Gibbs operators are created —
+ * {@code A} stays as a constant identity-pattern scaffold (skipped from operators and logging).
+ *
+ * <p>Mirrors the teardown-and-replace pattern of {@link GT16ErrorModelToBEAST}.</p>
+ *
+ * <p>beast3 note: LPhyBeast 2.0 dropped {@code BEASTContext.getAsRealParameter}; the read-count
+ * parameters are fetched via {@link BEASTContext#getBEASTObject} (the classic {@code RealParameter}
+ * produced for an LPhy value, exactly as {@code GT10ToBEAST} does for the nucleotide rates), so they
+ * can drive the {@code Function}/{@code StateNode}-based AVMN and up/down operators below.</p>
+ */
+public class ReadCountModelToBEAST implements GeneratorToBEAST<ReadCountModel, ReadCountTreeLikelihood> {
     @Override
-    public LikelihoodReadCountModel generatorToBEAST(ReadCountModel generator, BEASTInterface value, BEASTContext context) {
-        LikelihoodReadCountModel likelihoodReadCountModel = new LikelihoodReadCountModel();
-        //Get value from LPhy
-        String epsilonParamName = "epsilon";
-        String alphaParamName = "alpha";
-        String deltaParamName = "delta";
-        String covParamName = "coverage";
-        String tParamName = "t";
-        String vParamName = "v";
-        String sParamName = "s";
-        String w1ParamName = "w1";
-        String w2ParamName = "w2";
-        String alignmentParamName = "D";
+    public ReadCountTreeLikelihood generatorToBEAST(ReadCountModel generator, BEASTInterface value, BEASTContext context) {
+        // ---- pull the LPhy parameter values ----
+        Value epsilonValue = generator.getParams().get("epsilon");
+        Value alphaValue = generator.getParams().get("alpha");
+        Value deltaValue = (Value) alphaValue.getGenerator().getParams().get("delta");
+        Value coverageValue = generator.getParams().get("coverage");
+        Value tValue = (Value) coverageValue.getGenerator().getParams().get("t");
+        Value vValue = (Value) coverageValue.getGenerator().getParams().get("v");
+        Value sValue = (Value) coverageValue.getGenerator().getParams().get("s");
+        Value w1Value = generator.getParams().get("w1");
+        Value w2Value = generator.getParams().get("w2");
+        Value alignmentValue = generator.getParams().get("D");
 
-        //get values from LPhy
-        Value epsilonValue = generator.getParams().get(epsilonParamName);
-        Value alphaValue = generator.getParams().get(alphaParamName);
-        Value deltaValue = (Value) alphaValue.getGenerator().getParams().get(deltaParamName);
-        Value coverageValue = generator.getParams().get(covParamName);
-        Value tValue = (Value) coverageValue.getGenerator().getParams().get(tParamName);
-        Value vValue = (Value) coverageValue.getGenerator().getParams().get(vParamName);
-        Value sValue = (Value) coverageValue.getGenerator().getParams().get(sParamName);
-        Value w1Value = generator.getParams().get(w1ParamName);
-        Value w2Value = generator.getParams().get(w2ParamName);
-        Value alignmentValue = generator.getParams().get(alignmentParamName);
+        // beast3: getBEASTObject returns the spec param produced for each LPhy value
+        // (RealScalarParam for the scalar distributions, RealVectorParam for s ~ ...replicates),
+        // which match the LikelihoodReadCountModel spec-param inputs directly (no cast needed).
+        BEASTInterface epsilonParam = context.getBEASTObject(epsilonValue);
+        BEASTInterface deltaParam = context.getBEASTObject(deltaValue);
+        BEASTInterface tParam = context.getBEASTObject(tValue);
+        BEASTInterface vParam = context.getBEASTObject(vValue);
+        BEASTInterface sParam = context.getBEASTObject(sValue);
+        BEASTInterface w1Param = context.getBEASTObject(w1Value);
+        BEASTInterface w2Param = context.getBEASTObject(w2Value);
 
-        //convert LPhy values to Beast objects
-        RealParameter epsilonParam = context.getAsRealParameter(epsilonValue);
-        RealParameter deltaParam = context.getAsRealParameter(deltaValue);
-        RealParameter tParam = context.getAsRealParameter(tValue);
-        RealParameter vParam = context.getAsRealParameter(vValue);
-        RealParameter sParam = context.getAsRealParameter(sValue);
-        RealParameter w1Param = context.getAsRealParameter(w1Value);
-        RealParameter w2Param = context.getAsRealParameter(w2Value);
-
-        BEASTInterface alignmentParam = context.getBEASTObject(alignmentValue);
-        if (alignmentParam == null) {
-            alignmentParam = context.getBEASTObject(alignmentValue.getId());
+        if (!(value instanceof ReadCount readCountData)) {
+            throw new IllegalArgumentException("Require read count data");
         }
 
-        //set input of likelihood model
+        // ---- build the read-count model as a per-genotype-likelihood HELPER (not a factor) ----
+        // No genotype alignment: the helper derives its scaffold (cells, sites) from the read counts,
+        // and the genotype datatype is set by ReadCountTreeLikelihood from the GT10/GT16 subst model.
+        LikelihoodReadCountModel likelihoodReadCountModel = new LikelihoodReadCountModel();
         likelihoodReadCountModel.setInputValue("epsilon", epsilonParam);
         likelihoodReadCountModel.setInputValue("delta", deltaParam);
         likelihoodReadCountModel.setInputValue("t", tParam);
@@ -73,140 +72,66 @@ public class ReadCountModelToBEAST implements GeneratorToBEAST<ReadCountModel, L
         likelihoodReadCountModel.setInputValue("s", sParam);
         likelihoodReadCountModel.setInputValue("w1", w1Param);
         likelihoodReadCountModel.setInputValue("w2", w2Param);
-        likelihoodReadCountModel.setInputValue("alignment", alignmentParam);
-        // beast readcount readCountData
-        if (value instanceof ReadCount readCountData) {
-            likelihoodReadCountModel.setInputValue("readCount", readCountData);
-        } else {
-            throw new IllegalArgumentException("Require read count data");
-        }
-
+        likelihoodReadCountModel.setInputValue("readCount", readCountData);
         likelihoodReadCountModel.initAndValidate();
 
-        List<Transform> transforms = new ArrayList<>();
-        List<Function> logFunctions = new ArrayList<>();
-        logFunctions.add(tParam);
-        logFunctions.add(vParam);
-        transforms.add(addLogTransform(logFunctions));
-        addAVMNOperator(context, transforms);
+        // ---- build the integrated tree likelihood (the single posterior factor) ----
+        // It builds its identity-pattern scaffold internally from the read counts (no data input).
+        PhyloCTMC phyloCTMC = (PhyloCTMC) alignmentValue.getGenerator();
 
-        List<StateNode> upStates = new ArrayList<>();
-        List<StateNode> downStates = new ArrayList<>();
-        downStates.add(tParam);
-        downStates.add(vParam);
-        addUpDownOperator(context, upStates, downStates);
+        ReadCountTreeLikelihood treeLikelihood = new ReadCountTreeLikelihood();
+        PhyloCTMCToBEAST.constructTreeAndBranchRate(phyloCTMC, treeLikelihood, context, true);
+        SiteModel siteModel = PhyloCTMCToBEAST.constructSiteModel(phyloCTMC, context);
+        treeLikelihood.setInputValue("siteModel", siteModel);
+        treeLikelihood.setInputValue("readCountModel", likelihoodReadCountModel);
+        treeLikelihood.initAndValidate();
+        treeLikelihood.setID((value.getID() != null ? value.getID() : "readCount") + ".treeLikelihood");
+        // the scaffold was built internally during initAndValidate only to satisfy the parent
+        // TreeLikelihood; drop it so the XML contains no genotype alignment (rebuilt from read counts)
+        treeLikelihood.dropScaffoldInput();
 
-        //context.addSkipOperator(sParam);
-        //context.addSkipLoggable(sParam);
-        try {
-            PhyloCTMC lphyTreeLikelihood = (PhyloCTMC) alignmentValue.getGenerator();
-            MATreeLikelihood maTreeLikelihood = (MATreeLikelihood) context.getBEASTObject(lphyTreeLikelihood);
-
-            //addGibbsAlignmentOperator(context, alignmentParam, maTreeLikelihood, likelihoodReadCountModel);
-            addGibbsSequenceOperator(context, alignmentParam, maTreeLikelihood, likelihoodReadCountModel) ;
-            context.addSkipOperator((StateNode) alignmentParam);
-        } catch (ClassCastException e) {
-            System.err.println("Could not cast "+ alignmentValue.getGenerator().getInfo().name() +" to PhyloCTMC");
+        // ---- the genotype alignment A is integrated out: remove A and its tree likelihood from the
+        //      model, so the XML contains no genotype alignment (the only data is the read counts) ----
+        BEASTInterface maTreeLikelihood = context.getBEASTObject(phyloCTMC);
+        if (maTreeLikelihood != null && maTreeLikelihood != treeLikelihood) {
+            context.removeBEASTObject(maTreeLikelihood);
+        }
+        BEASTInterface alignmentParam = context.getBEASTObject(alignmentValue);
+        if (alignmentParam == null) {
+            alignmentParam = context.getBEASTObject(alignmentValue.getId());
+        }
+        if (alignmentParam != null) {
+            context.removeBEASTObject(alignmentParam);
         }
 
+        // ---- tree-aware genotype reconstruction logger (replaces the sampled-alignment log) ----
+        addSampledGenotypeLogger(context, treeLikelihood, siteModel, likelihoodReadCountModel, readCountData);
 
-        return likelihoodReadCountModel;
+        // beast3 TODO: the PR added custom AVMN (log-transform over t,v) and up/down operators for
+        // the coverage parameters. Those use the classic Function/StateNode operator path, which the
+        // spec params don't fit (RealScalarParam is not a beast.base.core.Function). For now rely on
+        // LPhyBeast's default operator scheduling for the read-count parameters; re-add spec-package
+        // operators here for better mixing once available.
+
+        return treeLikelihood;
     }
 
-
-
-    private Transform addLogTransform(List<Function> functions) {
-
-        Transform.LogTransform logTransform = new Transform.LogTransform();
-        logTransform.setInputValue("f", functions);
-        logTransform.initAndValidate();
-        return logTransform;
+    private void addSampledGenotypeLogger(BEASTContext context, ReadCountTreeLikelihood treeLikelihood,
+                                          SiteModel siteModel, LikelihoodReadCountModel readCountModel,
+                                          ReadCount readCount) {
+        SampledGenotypeLogger logger = new SampledGenotypeLogger();
+        logger.setInputValue("tree", (Tree) treeLikelihood.treeInput.get());
+        logger.setInputValue("siteModel", siteModel);
+        BranchRateModel branchRateModel = treeLikelihood.branchRateModelInput.get();
+        if (branchRateModel != null) {
+            logger.setInputValue("branchRateModel", branchRateModel);
+        }
+        logger.setInputValue("readCountModel", readCountModel);
+        logger.setInputValue("readCount", readCount);
+        logger.initAndValidate();
+        logger.setID("sampledGenotype");
+        context.addExtraLoggable(logger);
     }
-
-    private Transform addNoTransform(List<Function> functions) {
-
-        Transform.NoTransform noTransform = new Transform.NoTransform();
-        noTransform.setInputValue("f", functions);
-        noTransform.initAndValidate();
-        return noTransform;
-    }
-
-    private Transform addLogitTransform(List<Function> functions) {
-
-        Transform.LogitTransform logitTransform = new Transform.LogitTransform();
-        logitTransform.setInputValue("f", functions);
-        logitTransform.initAndValidate();
-        return logitTransform;
-    }
-
-    private void addAVMNOperator(BEASTContext context, List<Transform> transforms) {
-        AdaptableVarianceMultivariateNormalOperator operator = new AdaptableVarianceMultivariateNormalOperator();
-
-
-        operator.setInputValue("weight", 8.0);
-        operator.setInputValue("coefficient", 1.0);
-        operator.setInputValue("scaleFactor", 1.0);
-        operator.setInputValue("beta", 0.05);
-        operator.setInputValue("initial", 200 * transforms.size());
-        operator.setInputValue("burnin", 100 * transforms.size());
-        operator.setInputValue("every", 1);
-        operator.setInputValue("allowNonsense", false);
-        operator.setInputValue("transformations", transforms);
-        operator.initAndValidate();
-        operator.setID("AVMN");
-
-        // add operator
-        context.addExtraOperator(operator);
-        // skip default operator schedule
-
-    }
-
-    private void addUpDownOperator(BEASTContext context, List<StateNode> upStateNode, List<StateNode> downStateNode) {
-        UpDownOperator operator = new UpDownOperator();
-        operator.setInputValue("up", upStateNode);
-        operator.setInputValue("down", downStateNode);
-        operator.setInputValue("weight", 3.0);
-        operator.setInputValue("scaleFactor", 0.75);
-
-
-        operator.initAndValidate();
-        operator.setID("upDownOperator");
-        context.addExtraOperator(operator);
-    }
-
-    private void addMutableAlignmentOperator(BEASTContext context, BEASTInterface alignment) {
-        MutableAlignmentOperator operator = new MutableAlignmentOperator();
-        operator.setInputValue("mutableAlignment", alignment);
-        operator.initAndValidate();
-        operator.setID("mutableAlignmentOperator");
-        context.addExtraOperator(operator);
-    }
-
-    private void addGibbsSequenceOperator(BEASTContext context, BEASTInterface alignment, MATreeLikelihood maTreeLikelihood, LikelihoodReadCountModel likelihoodReadCountModel) {
-        GibbsSequenceOperator operator = new GibbsSequenceOperator();
-        MutableAlignment mutableAlignment = (MutableAlignment) alignment;
-        operator.setInputValue("mutableAlignment", alignment);
-        operator.setInputValue("maTreeLikelihood", maTreeLikelihood);
-        operator.setInputValue("likelihoodReadCountModel", likelihoodReadCountModel);
-        operator.setInputValue("weight", Math.pow(mutableAlignment.getTaxonCount(), 0.5));
-        operator.initAndValidate();
-        operator.setID("gibbsSequenceOperator");
-        context.addExtraOperator(operator);
-    }
-
-    private void addGibbsAlignmentOperator(BEASTContext context, BEASTInterface alignment, MATreeLikelihood maTreeLikelihood, LikelihoodReadCountModel likelihoodReadCountModel) {
-        GibbsAlignmentOperator operator = new GibbsAlignmentOperator();
-        MutableAlignment mutableAlignment = (MutableAlignment) alignment;
-        operator.setInputValue("mutableAlignment", alignment);
-        operator.setInputValue("maTreeLikelihood", maTreeLikelihood);
-        operator.setInputValue("likelihoodReadCountModel", likelihoodReadCountModel);
-        operator.setInputValue("weight", Math.pow(1, 0.5));
-        operator.initAndValidate();
-        operator.setID("gibbsAlignmentOperator");
-        context.addExtraOperator(operator);
-    }
-
-
 
     @Override
     public Class<ReadCountModel> getGeneratorClass() {
@@ -214,9 +139,7 @@ public class ReadCountModelToBEAST implements GeneratorToBEAST<ReadCountModel, L
     }
 
     @Override
-    public Class<LikelihoodReadCountModel> getBEASTClass() {
-        return LikelihoodReadCountModel.class;
+    public Class<ReadCountTreeLikelihood> getBEASTClass() {
+        return ReadCountTreeLikelihood.class;
     }
-
-
 }

--- a/phylonco-lphybeast/src/test/java/phylonco/lphybeast/integration/ReadCountModelXMLTest.java
+++ b/phylonco-lphybeast/src/test/java/phylonco/lphybeast/integration/ReadCountModelXMLTest.java
@@ -1,0 +1,84 @@
+package phylonco.lphybeast.integration;
+
+import beast.base.parser.XMLParser;
+import lphybeast.LPhyBeastCMD;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static beast.pkgmgmt.BEASTClassLoader.addServices;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end check of {@link phylonco.lphybeast.tobeast.generators.ReadCountModelToBEAST}: runs a
+ * GT10 read-count LPhy script through LPhyBeast and asserts the produced XML is the integrated model
+ * — a single {@code ReadCountTreeLikelihood} factor and a {@code SampledGenotypeLogger}, with the
+ * old sampled-genotype machinery (MATreeLikelihood / genotype Gibbs operators) gone.
+ */
+public class ReadCountModelXMLTest {
+
+    @Test
+    public void testReadCountIntegratedXML() throws Exception {
+        // Absolute paths: LPhyBeast switches the working dir to the script's folder, which would
+        // break relative-path resolution in its input validation.
+        Path script = Paths.get("src/test/resources/gt10ReadCountIntegrated.lphy").toAbsolutePath();
+        Path out = Paths.get("target/gt10ReadCountIntegrated.xml").toAbsolutePath();
+        Files.deleteIfExists(out);
+
+        // -vf registers BEAST2 services from version.xml files. lphybeast.version.xml supplies the
+        // lphybeast core SPI (LPhyBEASTMapping etc.) and version.xml supplies phylonco's LBPhylonco
+        // extension, so generation works headlessly without the BEAST packages being installed.
+        String[] args = {
+                "-seed", "777",
+                "-vf", "lphybeast.version.xml",
+                "-vf", "version.xml",
+                "-l", "2000", // must be >= LPhyBeastConfig.NUM_OF_SAMPLES (2000)
+                "-o", out.toString(),
+                script.toString()
+        };
+        int exitCode = new CommandLine(new LPhyBeastCMD()).execute(args);
+        assertEquals(0, exitCode, "LPhyBeast generation should succeed");
+        assertTrue(Files.exists(out), "XML should be generated at " + out.toAbsolutePath());
+
+        String xml = Files.readString(out);
+
+        // the integrated model: read-count tip-partial tree likelihood + tree-aware genotype logger
+        assertTrue(xml.contains("ReadCountTreeLikelihood"),
+                "XML must contain a ReadCountTreeLikelihood factor");
+        assertTrue(xml.contains("SampledGenotypeLogger") || xml.contains("sampledGenotype"),
+                "XML must contain the SampledGenotypeLogger");
+
+        // the old sampled-genotype machinery must be gone
+        assertFalse(xml.contains("MATreeLikelihood"),
+                "XML must NOT contain the old MATreeLikelihood");
+        assertFalse(xml.contains("GibbsSiteOperator") || xml.contains("GibbsAlignmentOperator")
+                        || xml.contains("GibbsSequenceOperator"),
+                "XML must NOT contain genotype Gibbs operators");
+
+        // ---- run the generated XML through BEAST for a short chain (parse + MCMC integrity) ----
+        // register the phylonco BEAST classes and MutableAlignment as BEAST2 services
+        addServices(Paths.get("..", "phylonco-beast", "version.xml").toString());
+        addServices(Paths.get("..", "phylonco-beast", "lib", "MutableAlignment.version.xml").toString());
+
+        // parseFile builds and initialises the full model graph (initAndValidate on every object,
+        // incl. ReadCountTreeLikelihood rebuilding its scaffold from the read counts) — it throws if
+        // the generated XML is not a valid, wireable BEAST model.
+        beast.base.inference.MCMC mcmc =
+                (beast.base.inference.MCMC) new XMLParser().parseFile(out.toFile());
+
+        // the model must produce a finite initial posterior (exercises the integrated tip-partial
+        // likelihood end-to-end on the generated XML). Set up the State and do the robust posterior
+        // calculation exactly as MCMC.run() does at start-up.
+        beast.base.inference.Distribution posterior = mcmc.posteriorInput.get();
+        beast.base.inference.State state = mcmc.startStateInput.get();
+        state.initAndValidate();
+        state.setPosterior(posterior);
+        double logP = state.robustlyCalcPosterior(posterior);
+        assertTrue(Double.isFinite(logP), "initial posterior must be finite, was " + logP);
+    }
+}

--- a/phylonco-lphybeast/src/test/resources/gt10ReadCountIntegrated.lphy
+++ b/phylonco-lphybeast/src/test/resources/gt10ReadCountIntegrated.lphy
@@ -1,0 +1,23 @@
+data {
+n = 20;
+l = 1000;
+}
+
+model {
+Θ ~ LogNormal(meanlog=-2.0, sdlog=1.0);
+ψ ~ Coalescent(n=n, theta=Θ);
+π ~ Dirichlet(conc=[3.0,3.0,3.0,3.0,3.0,3.0,3.0,3.0,3.0,3.0]);
+rates ~ Dirichlet(conc=[1.0, 2.0, 1.0, 1.0, 2.0, 1.0]);
+Q = gt10(freq=π, rates=rates);
+A ~ PhyloCTMC(L=l, Q=Q, tree=ψ, dataType=unphasedGenotype());
+w1 ~ LogNormal(meanlog= 3.96, sdlog= 0.33);
+w2 ~ LogNormal(meanlog= 0.93, sdlog= 0.33);
+epsilon ~ Beta(alpha= 1.5, beta= 1000);
+delta ~ Beta(alpha= 15, beta= 85);
+t ~ LogNormal(meanlog = 1.70, sdlog = 0.05); //coverage 5-6
+v ~ LogNormal(meanlog = 2.96, sdlog = 0.13); // variance 15-25
+s ~ LogNormal(meanlog= 0.2, sdlog= 0.72, replicates=n);
+alpha ~ Ploidy(l= l, n= n, delta= delta);
+cov ~ CoverageModel(alpha= alpha, t= t, v= v, s= s);
+r ~ ReadCountModel(D=A, epsilon=epsilon, alpha=alpha, coverage=cov, w1=w1, w2=w2);
+}

--- a/phylonco-lphybeast/version.xml
+++ b/phylonco-lphybeast/version.xml
@@ -16,8 +16,10 @@
 <!-- any ? -->
     </service>
 
-    <!-- add lphybeast ext below  -->
-    <service type="lphybeast.spi.LPhyBEASTExt">
+    <!-- add lphybeast ext below: LBPhylonco implements lphybeast.spi.LPhyBEASTMapping, which is the
+         service type lphybeast core discovers via BEASTClassLoader.loadService(LPhyBEASTMapping.class)
+         (the old "LPhyBEASTExt" type was never found, so phylonco's generators didn't load). -->
+    <service type="lphybeast.spi.LPhyBEASTMapping">
         <provider classname="phylonco.lphybeast.spi.LBPhylonco"/>
     </service>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,14 @@
 
     <build>
         <plugins>
+            <!-- Pin a compiler plugin whose bundled ASM can read JDK 25 (class major 69) bytecode;
+                 the inherited default (3.13.0) fails with "Unsupported class file major version 69"
+                 against the beast 2.8 dependencies. phylonco-beast already pins the same version. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>


### PR DESCRIPTION
Ports the analytic genotype-integration model from #128 onto **beast3** (BEAST 2.8 spec params, Java modules, JUnit4, apache math4). On this branch the genotypes are integrated out via read-count tip partials **and the genotype alignment is removed from the model entirely — the only data is the read counts** (no `MutableAlignment` / no `<data>` in the generated XML).

## phylonco-beast
- **`ReadCountTreeLikelihood`** — each tip's Felsenstein partials are the per-genotype read-count likelihoods `P(reads | g)`; pruning over the GT16/GT10 substitution model marginalises the genotypes. The identity-pattern scaffold the parent `TreeLikelihood` needs is built **internally from the `ReadCount`** (taxa, site count) with the genotype datatype read from the GT10/GT16 substitution model. `dropScaffoldInput()` keeps that scaffold out of the serialised XML; BEAST rebuilds it from the read counts at parse time.
- **`LikelihoodReadCountModel`** — `alignment` input now optional; derives cells/sites from the `ReadCount` and takes its genotype datatype via `setDataType()`. Spec param inputs (`RealScalarParam`/`RealVectorParam`), `LogGamma.value`.
- **`SampledGenotypeLogger`** — tree-aware per-cell genotype reconstruction; typed against `SiteModelInterface.Base` and the `BranchRateModel` interface for spec/classic compatibility.
- `module-info` + `version.xml` register the two new classes.
- **`ReadCountTreeLikelihoodTest`** (JUnit4 + spec-param construction): 4/4 pass against a hand Felsenstein integral, underflow, param round-trip, store/restore.

## phylonco-lphybeast
- **`ReadCountModelToBEAST`** — emits the integrated model (single `ReadCountTreeLikelihood` factor, `LikelihoodReadCountModel` helper, **no genotype alignment**, `SampledGenotypeLogger`); removes `A` and its tree likelihood from the LPhyBeast context. Uses `getBEASTObject` (LPhyBeast 2.0 dropped `getAsRealParameter`) and passes the spec params straight to the spec-param model inputs.
- **`ReadCountModelXMLTest`** — generates the XML from `gt10ReadCountIntegrated.lphy` via LPhyBeast, asserts there is **no `MutableAlignment`/alignment** in the XML, then loads it into BEAST and verifies a **finite initial posterior**. `lphybeast.version.xml` registers the lphybeast core SPI so headless generation works without installed BEAST packages.

## beast3 fixes that were required to build + run (pre-existing / spec-param migration)
- `phylonco-lphybeast/version.xml` registered `LBPhylonco` under the **wrong** service type (`LPhyBEASTExt`); it must be `lphybeast.spi.LPhyBEASTMapping`, otherwise phylonco's generators are never discovered.
- `GT10ToBEAST` / `GT16ToBEAST` / `GTUnphaseToBEAST` compiled but failed at runtime under spec params (`SimplexParam` vs classic `RealParameter`; spec vs classic `TreeLikelihood`). Switched to spec types / common supertypes; the frequency operators are deferred to LPhyBeast's default operator scheduling (marked with TODOs) pending a spec-operator migration.
- Root `pom.xml` pins `maven-compiler-plugin` 3.15.0 (the inherited default can't read JDK 25 / class major 69 bytecode).

## Verification
- Whole reactor builds on `beast-base:2.8.0-beta5` / JDK 25.
- `ReadCountTreeLikelihoodTest` 4/4 and `ReadCountModelXMLTest` pass.
- Pre-existing failure on `origin/beast3` (`LikelihoodReadCountModelTest.testReadCountModel`, a nexus-parsing issue) is unrelated to this change.

## Notes for review
- `phylonco-lphybeast/lphybeast.version.xml` is a test-harness convenience that re-registers the lphybeast core SPI for headless runs; not needed when the BEAST packages are installed.
- The GT10/GT16 frequency-operator migration to the spec-package operators is left as a follow-up (TODOs in those generators).
