### PR TITLE
Add BactrianSubtreeScale operator

### DIFF
--- a/phylonco-beast/src/main/java/module-info.java
+++ b/phylonco-beast/src/main/java/module-info.java
@@ -20,6 +20,7 @@ module phylonco.beast {
     exports phylonco.beast.evolution.likelihood;
     exports phylonco.beast.evolution.readcountmodel;
     exports phylonco.beast.evolution.substitutionmodel;
+    exports phylonco.beast.evolution.operator;
 
     provides beast.base.core.BEASTInterface with
             phylonco.beast.evolution.datatype.NucleotideDiploid10,
@@ -44,5 +45,6 @@ module phylonco.beast {
             phylonco.beast.evolution.readcountmodel.LikelihoodReadCountModel,
             phylonco.beast.evolution.readcountmodel.GibbsSequenceOperator,
             phylonco.beast.evolution.readcountmodel.GibbsAlignmentOperator,
-            phylonco.beast.evolution.datatype.ReadCount;
+            phylonco.beast.evolution.datatype.ReadCount,
+            phylonco.beast.evolution.operator.BactrianSubtreeScale;
 }

--- a/phylonco-beast/src/main/java/phylonco/beast/evolution/operator/BactrianSubtreeScale.java
+++ b/phylonco-beast/src/main/java/phylonco/beast/evolution/operator/BactrianSubtreeScale.java
@@ -1,0 +1,257 @@
+package phylonco.beast.evolution.operator;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+import beast.base.core.Description;
+import beast.base.core.Input;
+import beast.base.evolution.operator.TreeOperator;
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beast.base.inference.operator.kernel.KernelDistribution;
+import beast.base.inference.util.InputUtil;
+import beast.base.util.Randomizer;
+
+/**
+ * Subtree-slide move that proposes the moved node's height by scaling, in log
+ * space, the branch between the node and the subtree it carries.
+ *
+ * <p>When a node {@code p} is slid, it carries the subtree rooted at one of its
+ * children ({@code i}); that subtree's heights do not change, so {@code i}'s
+ * height is a hard floor for {@code p}. {@link beast.base.evolution.operator.kernel.BactrianSubtreeSlide}
+ * proposes {@code p}'s height additively, so a downward step routinely overshoots
+ * this floor and is flat-rejected ({@code NEGATIVE_INFINITY}); with a large step
+ * size that flat-rejection dominates and the operator cannot be auto-tuned into a
+ * useful regime.</p>
+ *
+ * <p>This operator instead proposes
+ * <pre>
+ *   gap'    = gap * exp(size * kernel)        // kernel is a mean-0 Bactrian draw
+ *   height' = floor + gap'
+ * </pre>
+ * where {@code gap = p.height - floor > 0}. Because {@code gap' > 0} for any draw,
+ * the move can never put {@code p} below the carried subtree, so that source of
+ * rejection is removed by construction. The proposal is also scale-invariant with
+ * respect to branch length, so a single {@code size} works across branches of very
+ * different lengths and the operator auto-optimises cleanly.</p>
+ *
+ * <h3>Hastings ratio</h3>
+ * <p>The proposal factorises into the continuous height move and the discrete
+ * reattachment, so {@code logHR = log(scale) + combinatorial}, where
+ * {@code log(scale) = log(gap'/gap)} is the standard scale-operator Jacobian and the
+ * combinatorial term ({@code -log(#sources)} up, {@code +log(#destinations)} down,
+ * {@code 0} for a pure node-age move) is identical to {@code BactrianSubtreeSlide}.</p>
+ *
+ * <p>Rejections from the destination side remain (e.g. in non-ultrametric trees the
+ * proposed height can fall below every leaf of the reattachment subtree, leaving no
+ * straddling edge); these are inherent to subtree slide and are not affected here.</p>
+ */
+@Description("Subtree-slide move that scales the branch above the carried subtree in log space, "
+        + "so the moved node can never be proposed below the carried subtree (removing that flat rejection) "
+        + "and the step is scale-invariant w.r.t. branch length, making it easier to auto-optimise than "
+        + "an additive subtree slide.")
+public class BactrianSubtreeScale extends TreeOperator {
+
+    final public Input<Double> sizeInput = new Input<>("size",
+            "scale of the log-space random walk on the gap above the carried subtree, default 0.3", 0.3);
+    final public Input<KernelDistribution> kernelDistributionInput = new Input<>("kernelDistribution",
+            "provides sample distribution for proposals", KernelDistribution.newDefaultKernelDistribution());
+    final public Input<Boolean> optimiseInput = new Input<>("optimise",
+            "flag to indicate that the size is automatically changed to achieve a good acceptance rate (default true)", true);
+
+    private double size;
+    private KernelDistribution kernelDistribution;
+
+    @Override
+    public void initAndValidate() {
+        size = sizeInput.get();
+        kernelDistribution = kernelDistributionInput.get();
+    }
+
+    @Override
+    public double proposal() {
+        final Tree tree = (Tree) InputUtil.get(treeInput, this);
+
+        // 1. choose a random node avoiding the root; p is the node being slid.
+        final int nodeCount = tree.getNodeCount();
+        Node i;
+        do {
+            i = tree.getNode(Randomizer.nextInt(nodeCount));
+        } while (i.isRoot());
+
+        final Node p = i.getParent();
+        final Node CiP = getOtherChild(p, i);   // sibling that p slides past / into
+        final Node PiP = p.getParent();
+
+        // 2. carried subtree (rooted at i) sets the floor; scale the gap above it.
+        final double floor = i.getHeight();
+        final double oldHeight = p.getHeight();
+        final double oldGap = oldHeight - floor;
+        if (oldGap <= 0.0) {
+            // zero-length branch (e.g. sampled ancestor): nothing to scale
+            return Double.NEGATIVE_INFINITY;
+        }
+
+        final double logScale = kernelDistribution.getRandomDelta(0, Double.NaN, size); // size * mean-0 draw
+        final double scale = Math.exp(logScale);
+        final double newHeight = floor + oldGap * scale;
+
+        // Jacobian of the scale move on the gap.
+        double logq = logScale;
+
+        // 3. if the move is up
+        if (newHeight > oldHeight) {
+
+            // 3.1 if the topology will change
+            if (PiP != null && PiP.getHeight() < newHeight) {
+                // find new parent
+                Node newParent = PiP;
+                Node newChild = p;
+                while (newParent.getHeight() < newHeight) {
+                    newChild = newParent;
+                    newParent = newParent.getParent();
+                    if (newParent == null) break;
+                }
+
+                // 3.1.1 if creating a new root
+                if (newChild.isRoot()) {
+                    replace(p, CiP, newChild);
+                    replace(PiP, p, CiP);
+
+                    p.setParent(null);
+                    tree.setRoot(p);
+                }
+                // 3.1.2 no new root
+                else {
+                    replace(p, CiP, newChild);
+                    replace(PiP, p, CiP);
+                    replace(newParent, newChild, p);
+                }
+
+                p.setHeight(newHeight);
+
+                // 3.1.3 count the hypothetical sources of this destination.
+                final int possibleSources = intersectingEdges(newChild, oldHeight, null);
+                logq -= Math.log(possibleSources);
+
+            } else {
+                // just change the node height
+                p.setHeight(newHeight);
+            }
+        }
+        // 4. if we are sliding the subtree down
+        else {
+
+            // 4.0 is it a valid move? By construction newHeight > floor = i.getHeight(),
+            // so the carried-subtree bound can never be violated. Guard defensively.
+            if (i.getHeight() > newHeight) {
+                return Double.NEGATIVE_INFINITY;
+            }
+
+            // 4.1 will the move change the topology
+            if (CiP.getHeight() > newHeight) {
+
+                final List<Node> newChildren = new ArrayList<>();
+                final int possibleDestinations = intersectingEdges(CiP, newHeight, newChildren);
+
+                // if no valid destinations then return a failure (e.g. non-ultrametric leaf ages)
+                if (newChildren.size() == 0) {
+                    return Double.NEGATIVE_INFINITY;
+                }
+
+                // pick a random parent/child destination edge uniformly from options
+                final int childIndex = Randomizer.nextInt(newChildren.size());
+                final Node newChild = newChildren.get(childIndex);
+                final Node newParent = newChild.getParent();
+
+                // 4.1.1 if p was root
+                if (p.isRoot()) {
+                    replace(p, CiP, newChild);
+                    replace(newParent, newChild, p);
+
+                    CiP.setParent(null);
+                    tree.setRoot(CiP);
+
+                } else {
+                    replace(p, CiP, newChild);
+                    replace(PiP, p, CiP);
+                    replace(newParent, newChild, p);
+                }
+
+                p.setHeight(newHeight);
+
+                logq += Math.log(possibleDestinations);
+            } else {
+                p.setHeight(newHeight);
+            }
+        }
+        return logq;
+    }
+
+    protected int intersectingEdges(Node node, double height, List<Node> directChildren) {
+        final Node parent = node.getParent();
+
+        if (parent.getHeight() < height) return 0;
+
+        if (node.getHeight() < height) {
+            if (directChildren != null) directChildren.add(node);
+            return 1;
+        }
+
+        if (node.isLeaf()) {
+            return 0;
+        } else {
+            return intersectingEdges(node.getLeft(), height, directChildren) +
+                    intersectingEdges(node.getRight(), height, directChildren);
+        }
+    }
+
+    /**
+     * automatic parameter tuning *
+     */
+    @Override
+    public void optimize(final double logAlpha) {
+        if (optimiseInput.get()) {
+            // size is a Bactrian scale: larger size means larger jumps. Tune multiplicatively
+            // so acceptance too high (delta > 0) increases size, too low decreases it.
+            double delta = calcDelta(logAlpha);
+            delta += Math.log(size);
+            size = Math.exp(delta);
+        }
+    }
+
+    @Override
+    public double getCoercableParameterValue() {
+        return size;
+    }
+
+    @Override
+    public void setCoercableParameterValue(final double value) {
+        size = value;
+    }
+
+    @Override
+    public double getTargetAcceptanceProbability() {
+        return 0.3;
+    }
+
+    @Override
+    public String getPerformanceSuggestion() {
+        final double prob = m_nNrAccepted / (m_nNrAccepted + m_nNrRejected + 0.0);
+        final double targetProb = getTargetAcceptanceProbability();
+
+        double ratio = prob / targetProb;
+        if (ratio > 2.0) ratio = 2.0;
+        if (ratio < 0.5) ratio = 0.5;
+
+        final double newSize = size * ratio;
+
+        final DecimalFormat formatter = new DecimalFormat("#.###");
+        if (prob < 0.10) {
+            return "Try decreasing size to about " + formatter.format(newSize);
+        } else if (prob > 0.40) {
+            return "Try increasing size to about " + formatter.format(newSize);
+        } else return "";
+    }
+}

--- a/phylonco-beast/src/test/java/phylonco/beast/evolution/operator/BactrianSubtreeScaleTest.java
+++ b/phylonco-beast/src/test/java/phylonco/beast/evolution/operator/BactrianSubtreeScaleTest.java
@@ -1,0 +1,181 @@
+package phylonco.beast.evolution.operator;
+
+import beast.base.evolution.operator.kernel.BactrianSubtreeSlide;
+import beast.base.inference.Operator;
+import beast.base.evolution.operator.ScaleOperator;
+import beast.base.evolution.operator.Uniform;
+import beast.base.evolution.speciation.YuleModel;
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import beast.base.evolution.tree.TreeStatLogger;
+import beast.base.inference.CompoundDistribution;
+import beast.base.inference.Distribution;
+import beast.base.inference.Logger;
+import beast.base.inference.MCMC;
+import beast.base.inference.State;
+import beast.base.inference.parameter.RealParameter;
+import beast.base.util.Randomizer;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link BactrianSubtreeScale}.
+ *
+ * <p>Two checks:</p>
+ * <ol>
+ *   <li><b>Mechanics</b> — on an ultrametric tree the operator never proposes a node below
+ *       its carried subtree (no negative branches) and never flat-rejects from that bound.</li>
+ *   <li><b>Detailed balance</b> — sampling a Yule prior with this operator reproduces the same
+ *       tree-height distribution as the trusted {@link BactrianSubtreeSlide}; a wrong Hastings
+ *       ratio would bias the height.</li>
+ * </ol>
+ */
+public class BactrianSubtreeScaleTest {
+
+    private static final String NEWICK =
+            "((A:2,B:2):1,(C:2,(D:1,(E:0.5,F:0.5):0.5):1):1):0;";
+
+    private Tree newTree() {
+        Tree tree = new TreeParser();
+        tree.initByName(
+                "newick", NEWICK,
+                "IsLabelledNewick", true,
+                "adjustTipHeights", false);
+        return tree;
+    }
+
+    /** Every non-root node must sit strictly below its parent (no zero/negative branches). */
+    private void assertValid(Tree tree) {
+        for (Node node : tree.getNodesAsArray()) {
+            if (!node.isRoot()) {
+                assertTrue("node " + node.getNr() + " height " + node.getHeight()
+                                + " not below parent " + node.getParent().getHeight(),
+                        node.getHeight() < node.getParent().getHeight() + 1e-12);
+            }
+            assertTrue("negative height", node.getHeight() >= 0.0);
+        }
+    }
+
+    @Test
+    public void testFloorNeverViolated() {
+        Randomizer.setSeed(42);
+        Tree tree = newTree();
+
+        BactrianSubtreeScale op = new BactrianSubtreeScale();
+        op.initByName("tree", tree, "size", 0.5, "weight", 1.0);
+
+        int infinite = 0;
+        final int N = 20000;
+        for (int k = 0; k < N; k++) {
+            double logHR = op.proposal();
+            if (logHR == Double.NEGATIVE_INFINITY) {
+                infinite++;
+                // tree must be untouched on a rejected-before-mutation proposal
+                assertValid(tree);
+            } else {
+                assertTrue("non-finite logHR " + logHR, !Double.isNaN(logHR) && !Double.isInfinite(logHR));
+                assertValid(tree);
+            }
+        }
+        // on an ultrametric tree the carried-subtree floor and the destination check can never fire
+        assertTrue("unexpected flat rejects on ultrametric tree: " + infinite, infinite == 0);
+    }
+
+    /** Mean tree height over the post-burnin samples of a 2-column (Sample, height) trace file. */
+    private double meanHeight(Path log) throws IOException {
+        List<String> lines = Files.readAllLines(log);
+        List<Double> heights = new ArrayList<>();
+        for (String line : lines) {
+            if (line.startsWith("Sample") || line.startsWith("#") || line.trim().isEmpty()) continue;
+            String[] f = line.split("\\s+");
+            if (f.length < 2) continue;
+            try {
+                heights.add(Double.parseDouble(f[1]));
+            } catch (NumberFormatException ignore) {
+                // header / non-numeric
+            }
+        }
+        int burnin = heights.size() / 10;
+        double sum = 0;
+        int n = 0;
+        for (int k = burnin; k < heights.size(); k++) {
+            sum += heights.get(k);
+            n++;
+        }
+        return sum / n;
+    }
+
+    private double sampleYuleMeanHeight(Operator treeMove, Tree tree, long seed) throws Exception {
+        Randomizer.setSeed(seed);
+
+        RealParameter birthRate = new RealParameter("1.0");
+
+        YuleModel yule = new YuleModel();
+        yule.initByName("tree", tree, "birthDiffRate", birthRate);
+
+        State state = new State();
+        state.initByName("stateNode", tree);
+
+        CompoundDistribution posterior = new CompoundDistribution();
+        posterior.initByName("distribution", (Distribution) yule);
+
+        Uniform uniform = new Uniform();
+        uniform.initByName("tree", tree, "weight", 3.0);
+
+        ScaleOperator scale = new ScaleOperator();
+        scale.initByName("tree", tree, "scaleFactor", 0.75, "weight", 1.0);
+
+        List<Operator> operators = new ArrayList<>();
+        operators.add(uniform);
+        operators.add(scale);
+        operators.add(treeMove);
+
+        Path logFile = Files.createTempFile("subtreeScaleTest", ".log");
+        Files.delete(logFile); // let BEAST create it fresh
+
+        TreeStatLogger heightLogger = new TreeStatLogger();
+        heightLogger.initByName("tree", tree, "logLength", false);
+
+        Logger logger = new Logger();
+        logger.initByName("logEvery", 2000, "fileName", logFile.toString(), "log", heightLogger);
+
+        MCMC mcmc = new MCMC();
+        mcmc.initByName(
+                "chainLength", 6000000L,
+                "state", state,
+                "distribution", posterior,
+                "operator", operators,
+                "logger", logger);
+
+        mcmc.run();
+
+        return meanHeight(logFile);
+    }
+
+    @Test
+    public void testYuleHeightMatchesSubtreeSlide() throws Exception {
+        // reference: trusted additive subtree slide
+        Tree refTree = newTree();
+        BactrianSubtreeSlide slide = new BactrianSubtreeSlide();
+        slide.initByName("tree", refTree, "weight", 5.0);
+        double meanSlide = sampleYuleMeanHeight(slide, refTree, 123);
+
+        // operator under test
+        Tree testTree = newTree();
+        BactrianSubtreeScale scaleMove = new BactrianSubtreeScale();
+        scaleMove.initByName("tree", testTree, "size", 0.5, "weight", 5.0);
+        double meanScale = sampleYuleMeanHeight(scaleMove, testTree, 321);
+
+        double relDiff = Math.abs(meanScale - meanSlide) / meanSlide;
+        assertTrue("Yule mean tree height disagrees: slide=" + meanSlide
+                + " scale=" + meanScale + " relDiff=" + relDiff, relDiff < 0.05);
+    }
+}

--- a/phylonco-beast/version.xml
+++ b/phylonco-beast/version.xml
@@ -38,6 +38,7 @@
         <provider classname="phylonco.beast.evolution.readcountmodel.GibbsSequenceOperator"/>
         <provider classname="phylonco.beast.evolution.readcountmodel.GibbsAlignmentOperator"/>
         <provider classname="phylonco.beast.evolution.datatype.ReadCount"/>
+        <provider classname="phylonco.beast.evolution.operator.BactrianSubtreeScale"/>
     </service>
 
 </package>


### PR DESCRIPTION
Adds a new tree operator, `phylonco.beast.evolution.operator.BactrianSubtreeScale`, for Yao to test on the read-count analyses.

## Motivation

In Yao's `RCTree` run on beast3, `BactrianSubtreeSlide` (`psi.subtreeSlide`) had catastrophic acceptance (~0.00002, 10 accepted / 579,801 rejected) with its step `size` stuck high (3.2). The additive slide proposes the moved node's height by `oldHeight + delta`; the node rigidly carries one child subtree whose height is a hard floor, so a large downward step routinely overshoots that floor and is flat-rejected. With one absolute `size` across heterogeneous branch lengths there is no good value, and harmonic (`1/count`) auto-tuning freezes it after the early phase.

## What this operator does

Propose the height by **scaling the gap above the carried subtree in log space**:

```
gap'    = gap * exp(size * bactrian)     // gap = p.height - carriedChild.height > 0
height' = carriedChild.height + gap'
```

- `gap' > 0` always, so the node can never be proposed below its carried subtree — that flat rejection is gone by construction.
- Scale-invariant w.r.t. branch length, so a single `size` works tree-wide and auto-optimisation converges (multiplicative tuning in the Bactrian direction).
- Hastings ratio = `log(scale)` (scale Jacobian) + the **same** combinatorial reattachment term as `BactrianSubtreeSlide` (`-log(#sources)` up, `+log(#destinations)` down, `0` for a pure node-age move).

Rejections from the destination side remain (e.g. in non-ultrametric trees a proposed height can fall below every leaf of the reattachment subtree) — these are inherent to subtree slide and unchanged.

## Validation (`BactrianSubtreeScaleTest`)

- **Mechanics:** 20,000 proposals on an ultrametric tree — zero flat rejects, every resulting tree valid (no node below its child).
- **Detailed balance:** sampling a Yule prior (6 taxa) with this operator reproduces the same tree-height distribution as the trusted `BactrianSubtreeSlide` (means agree within 5%); a wrong Jacobian would bias this.

Both tests pass (`mvn -pl phylonco-beast test -Dtest=BactrianSubtreeScaleTest`).

## How to test

Drop it into an analysis in place of (or alongside) the subtree slide, e.g.:

```xml
<operator id="psi.subtreeScale" spec="phylonco.beast.evolution.operator.BactrianSubtreeScale"
          tree="@psi" weight="15.0"/>
```

Then compare `Pr(acc|m)` and ESS against `subtreeSlide`.

## Follow-up

Registered in `phylonco-beast/version.xml`. If it performs well, the plan is to migrate the class into beast3 core (next to `BactrianSubtreeSlide`) and have LPhyBeast emit it.
